### PR TITLE
Updated to licence overrides for codemirror (JSGUI)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,3 @@
-
 This software is distributed under the Apache License, version 2.0. See (1) below.
 This software is copyright (c) The Apache Software Foundation and contributors.
 
@@ -194,6 +193,12 @@ Contents:
 
 (2) Notices for bundled software
 
+This project includes the software: anyword-hint.js
+  Available at: http://codemirror.net/
+  Version used: 5.11.1
+  Used under the following license: The MIT License (http://opensource.org/licenses/MIT)
+  CodeMirror (c) Marijn Haverbeke and others
+
 This project includes the software: async.js
   Available at: https://github.com/p15martin/google-maps-hello-world/blob/master/js/libs/async.js
   Developed by: Miller Medeiros (https://github.com/millermedeiros/)
@@ -213,6 +218,12 @@ This project includes the software: bootstrap.js
   Version used: 2.0.4
   Used under the following license: Apache License, version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
   Copyright (c) Twitter, Inc. (2012)
+
+This project includes the software: codemirror.{js,css}
+  Available at: http://codemirror.net/
+  Version used: 5.11.1
+  Used under the following license: The MIT License (http://opensource.org/licenses/MIT)
+  CodeMirror (c) Marijn Haverbeke and others
 
 This project includes the software: handlebars.js
   Available at: https://github.com/wycats/handlebars.js
@@ -278,7 +289,7 @@ This project includes the software: js-uri
 This project includes the software: js-yaml.js
   Available at: https://github.com/nodeca/
   Developed by: Vitaly Puzrin (https://github.com/nodeca/)
-  Version used: 3.2.7
+  Version used: 3.5.2
   Used under the following license: The MIT License (http://opensource.org/licenses/MIT)
   Copyright (c) Vitaly Puzrin (2011-2015)
 
@@ -295,6 +306,12 @@ This project includes the software: moment.js
   Version used: 2.1.0
   Used under the following license: The MIT License (http://opensource.org/licenses/MIT)
   Copyright (c) Tim Wood, Iskren Chernev, Moment.js contributors (2011-2014)
+
+This project includes the software: placeholder.js
+  Available at: http://codemirror.net/
+  Version used: 5.11.1
+  Used under the following license: The MIT License (http://opensource.org/licenses/MIT)
+  CodeMirror (c) Marijn Haverbeke and others
 
 This project includes the software: RequireJS
   Available at: http://requirejs.org/
@@ -330,6 +347,12 @@ This project includes the software: RequireJS (r.js maven plugin)
       Arpad Borsos (2012)
     Used under the BSD 2-Clause license.
 
+This project includes the software: show-hint.{js,css}
+  Available at: http://codemirror.net/
+  Version used: 5.11.1
+  Used under the following license: The MIT License (http://opensource.org/licenses/MIT)
+  CodeMirror (c) Marijn Haverbeke and others
+
 This project includes the software: Swagger UI
   Available at: https://github.com/swagger-api/swagger-ui
   Inclusive of: swagger*.{js,css,html}
@@ -359,6 +382,12 @@ This project includes the software: underscore.js:1.7.0
   Version used: 1.7.0
   Used under the following license: The MIT License (http://opensource.org/licenses/MIT)
   Copyright (c) Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors (2009-2014)
+
+This project includes the software: yaml.js
+  Available at: http://codemirror.net/
+  Version used: 5.11.1
+  Used under the following license: The MIT License (http://opensource.org/licenses/MIT)
+  CodeMirror (c) Marijn Haverbeke and others
 
 This project includes the software: ZeroClipboard
   Available at: http://zeroclipboard.org/

--- a/dist/licensing/overrides.yaml
+++ b/dist/licensing/overrides.yaml
@@ -232,6 +232,36 @@
   url: http://twitter.github.com/bootstrap/javascript.html#transitions
   notice: Copyright (c) Twitter, Inc. (2012)
   license: ASL2
+
+- id: codemirror.{js,css}
+  version: 5.11.1
+  url: http://codemirror.net/
+  notice: CodeMirror (c) Marijn Haverbeke and others
+  license: MIT
+
+- id: show-hint.{js,css}
+  version: 5.11.1
+  url: http://codemirror.net/
+  notice: CodeMirror (c) Marijn Haverbeke and others
+  license: MIT
+
+- id: placeholder.js
+  version: 5.11.1
+  url: http://codemirror.net/
+  notice: CodeMirror (c) Marijn Haverbeke and others
+  license: MIT
+
+- id: anyword-hint.js
+  version: 5.11.1
+  url: http://codemirror.net/
+  notice: CodeMirror (c) Marijn Haverbeke and others
+  license: MIT
+
+- id: yaml.js
+  version: 5.11.1
+  url: http://codemirror.net/
+  notice: CodeMirror (c) Marijn Haverbeke and others
+  license: MIT
  
 # used in docs (not needed for licensing) 
 - id: bootstrap.js:3.1.1
@@ -325,7 +355,7 @@
   notice: Copyright (c) js-uri contributors (2013)
 
 - id: js-yaml.js
-  version: 3.2.7
+  version: 3.5.2
   organization: { name: "Vitaly Puzrin", url: "https://github.com/nodeca/" }
   url: https://github.com/nodeca/
   notice: Copyright (c) Vitaly Puzrin (2011-2015)

--- a/dist/src/main/license/files/LICENSE
+++ b/dist/src/main/license/files/LICENSE
@@ -1,4 +1,3 @@
-
 This software is distributed under the Apache License, version 2.0. See (1) below.
 This software is copyright (c) The Apache Software Foundation and contributors.
 
@@ -194,13 +193,19 @@ Contents:
 
 (2) Notices for bundled software
 
+This project includes the software: anyword-hint.js
+  Available at: http://codemirror.net/
+  Version used: 5.11.1
+  Used under the following license: The MIT License (http://opensource.org/licenses/MIT)
+  CodeMirror (c) Marijn Haverbeke and others
+
 This project includes the software: aopalliance
   Available at: http://aopalliance.sourceforge.net
   Version used: 1.0
   Used under the following license: Public Domain
 
 This project includes the software: asm
-  Available at: http://asm.objectweb.org/
+  Available at: http://asm.objectweb.org/asm/
   Developed by: ObjectWeb (http://www.objectweb.org/)
   Version used: 3.3.1
   Used under the following license: BSD License (http://asm.objectweb.org/license.html)
@@ -231,6 +236,12 @@ This project includes the software: ch.qos.logback
   Version used: 1.0.7
   Used under the following license: Eclipse Public License, version 1.0 (http://www.eclipse.org/legal/epl-v10.html)
 
+This project includes the software: codemirror.{js,css}
+  Available at: http://codemirror.net/
+  Version used: 5.11.1
+  Used under the following license: The MIT License (http://opensource.org/licenses/MIT)
+  CodeMirror (c) Marijn Haverbeke and others
+
 This project includes the software: com.fasterxml.jackson.core
   Available at: http://github.com/FasterXML/jackson https://github.com/FasterXML/jackson
   Developed by: FasterXML (http://fasterxml.com/)
@@ -250,7 +261,7 @@ This project includes the software: com.fasterxml.jackson.datatype
   Used under the following license: Apache License, version 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 This project includes the software: com.fasterxml.jackson.jaxrs
-  Available at: http://wiki.fasterxml.com/JacksonHome
+  Available at: http://wiki.fasterxml.com/JacksonHome/jackson-jaxrs-json-provider http://wiki.fasterxml.com/JacksonHome/jackson-jaxrs-base
   Developed by: FasterXML (http://fasterxml.com/)
   Version used: 2.4.5
   Used under the following license: Apache License, version 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -273,24 +284,24 @@ This project includes the software: com.google.code.gson
   Used under the following license: Apache License, version 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 This project includes the software: com.google.guava
-  Available at: http://code.google.com/p/guava-libraries
+  Available at: http://code.google.com/p/guava-libraries/guava
   Version used: 17.0
   Used under the following license: Apache License, version 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 This project includes the software: com.google.http-client
-  Available at: http://code.google.com/p/google-http-java-client/
+  Available at: http://code.google.com/p/google-http-java-client/google-http-client/
   Developed by: Google (http://www.google.com/)
   Version used: 1.18.0-rc
   Used under the following license: Apache License, version 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 This project includes the software: com.google.inject
-  Available at: http://code.google.com/p/google-guice/
+  Available at: http://code.google.com/p/google-guice/guice/
   Developed by: Google, Inc. (http://www.google.com)
   Version used: 3.0
   Used under the following license: Apache License, version 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 This project includes the software: com.google.inject.extensions
-  Available at: http://code.google.com/p/google-guice/
+  Available at: http://code.google.com/p/google-guice/extensions-parent/
   Developed by: Google, Inc. (http://www.google.com)
   Version used: 3.0
   Used under the following license: Apache License, version 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -329,12 +340,12 @@ This project includes the software: com.maxmind.geoip2
   Used under the following license: Apache License, version 2.0 (http://www.apache.org/licenses/LICENSE-2.0.html)
 
 This project includes the software: com.squareup.okhttp
-  Available at: https://github.com/square/okhttp
+  Available at: https://github.com/square/okhttp/okhttp
   Version used: 2.2.0
   Used under the following license: Apache License, version 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 This project includes the software: com.squareup.okio
-  Available at: https://github.com/square/okio
+  Available at: https://github.com/square/okio/okio
   Version used: 1.2.0
   Used under the following license: Apache License, version 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -345,13 +356,13 @@ This project includes the software: com.sun.jersey
   Used under the following license: Common Development and Distribution License, version 1.1 (http://glassfish.java.net/public/CDDL+GPL_1_1.html)
 
 This project includes the software: com.sun.jersey.contribs
-  Available at: https://jersey.java.net/
+  Available at: https://jersey.java.net/jersey-contribs/jersey-multipart/
   Developed by: Oracle Corporation (http://www.oracle.com/)
   Version used: 1.19
   Used under the following license: Common Development and Distribution License, version 1.1 (http://glassfish.java.net/public/CDDL+GPL_1_1.html)
 
 This project includes the software: com.thoughtworks.xstream
-  Available at: http://x-stream.github.io/
+  Available at: http://codehaus.org/xstream-parent/xstream/
   Developed by: XStream (http://xstream.codehaus.org)
   Version used: 1.4.7
   Used under the following license: BSD License (http://xstream.codehaus.org/license.html)
@@ -412,17 +423,17 @@ This project includes the software: io.airlift
   Used under the following license: Apache License, version 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 This project includes the software: io.cloudsoft.windows
-  Available at: http://github.com/cloudsoft/winrm4j
+  Available at: http://github.com/cloudsoft/winrm4j/winrm4j http://github.com/cloudsoft/winrm4j/winrmj4-client
   Version used: 0.2.0
   Used under the following license: Apache License, version 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 This project includes the software: io.swagger
-  Available at: https://github.com/swagger-api/swagger-core
+  Available at: https://github.com/swagger-api/swagger-core/modules/
   Version used: 1.5.3
   Used under the following license: Apache License, version 2.0 (http://www.apache.org/licenses/LICENSE-2.0.html)
 
 This project includes the software: javax.annotation
-  Available at: https://jcp.org/en/jsr/detail?id=250
+  Available at: http://jcp.org/aboutJava/communityprocess/final/jsr250/index.html
   Version used: 1.0
   Used under the following license: Common Development and Distribution License, version 1.0 (https://glassfish.dev.java.net/public/CDDLv1.0.html)
 
@@ -443,7 +454,7 @@ This project includes the software: javax.validation
   Used under the following license: Apache License, version 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 This project includes the software: javax.ws.rs
-  Available at: https://jsr311.java.net/
+  Available at: https://jsr311.dev.java.net
   Developed by: Sun Microsystems, Inc (http://www.sun.com/)
   Version used: 1.1.1
   Used under the following license: CDDL License (http://www.opensource.org/licenses/cddl1.php)
@@ -510,7 +521,7 @@ This project includes the software: js-uri
 This project includes the software: js-yaml.js
   Available at: https://github.com/nodeca/
   Developed by: Vitaly Puzrin (https://github.com/nodeca/)
-  Version used: 3.2.7
+  Version used: 3.5.2
   Used under the following license: The MIT License (http://opensource.org/licenses/MIT)
   Copyright (c) Vitaly Puzrin (2011-2015)
 
@@ -539,7 +550,7 @@ This project includes the software: net.java.dev.jna
   Used under the following license: Apache License, version 2.0 (http://www.gnu.org/licenses/licenses.html)
 
 This project includes the software: net.minidev
-  Available at: http://www.minidev.net/
+  Available at: (invalid url reported: http://json-smart/) (invalid url reported: http://asm/)
   Developed by: Chemouni Uriel (http://www.minidev.net/)
   Version used: 2.1.1; 1.0.2
   Used under the following license: Apache License, version 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -562,13 +573,13 @@ This project includes the software: org.apache.commons
   Used under the following license: Apache License, version 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 This project includes the software: org.apache.felix
-  Available at: http://felix.apache.org/
+  Available at: http://felix.apache.org/org.apache.felix.framework/
   Developed by: The Apache Software Foundation (http://www.apache.org/)
   Version used: 4.4.0
   Used under the following license: Apache License, version 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 This project includes the software: org.apache.httpcomponents
-  Available at: http://hc.apache.org/httpcomponents-client-ga http://hc.apache.org/httpcomponents-core-ga
+  Available at: http://hc.apache.org/httpcomponents-client http://hc.apache.org/httpcomponents-core-ga
   Developed by: The Apache Software Foundation (http://www.apache.org/)
   Version used: 4.4.1
   Used under the following license: Apache License, version 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -580,31 +591,31 @@ This project includes the software: org.apache.jclouds
   Used under the following license: Apache License, version 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 This project includes the software: org.apache.jclouds.api
-  Available at: http://jclouds.apache.org/
+  Available at: http://jclouds.apache.org/s3/ http://jclouds.apache.org/atmos/ http://jclouds.apache.org/swift/ http://jclouds.apache.org/openstack-swift/ http://jclouds.apache.org/rackspace-cloudfiles/ http://jclouds.apache.org/openstack-nova/ http://jclouds.apache.org/openstack-keystone/ http://jclouds.apache.org/openstack-nova-ec2/ http://jclouds.apache.org/byon/ http://jclouds.apache.org/ec2/ http://jclouds.apache.org/sts/ http://jclouds.apache.org/elasticstack/ http://jclouds.apache.org/cloudstack/ http://jclouds.apache.org/rackspace-cloudidentity/
   Developed by: The Apache Software Foundation (http://www.apache.org/)
   Version used: 1.9.2
   Used under the following license: Apache License, version 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 This project includes the software: org.apache.jclouds.common
-  Available at: http://jclouds.apache.org/
+  Available at: http://jclouds.apache.org/openstack-common/
   Developed by: The Apache Software Foundation (http://www.apache.org/)
   Version used: 1.9.2
   Used under the following license: Apache License, version 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 This project includes the software: org.apache.jclouds.driver
-  Available at: http://jclouds.apache.org/
+  Available at: http://jclouds.apache.org/jclouds-slf4j/ http://jclouds.apache.org/jclouds-bouncycastle/ http://jclouds.apache.org/jclouds-sshj/ http://jclouds.apache.org/jclouds-okhttp/
   Developed by: The Apache Software Foundation (http://www.apache.org/)
   Version used: 1.9.2
   Used under the following license: Apache License, version 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 This project includes the software: org.apache.jclouds.labs
-  Available at: http://jclouds.apache.org/
+  Available at: http://jclouds.apache.org/jclouds-labs/abiquo/ http://jclouds.apache.org/jclouds-labs-google/google-compute-engine/ http://jclouds.apache.org/jclouds-labs-google/googlecloud/ http://jclouds.apache.org/jclouds-labs/oauth/ http://jclouds.apache.org/jclouds-labs/docker/
   Developed by: The Apache Software Foundation (http://www.apache.org/)
   Version used: 1.9.2
   Used under the following license: Apache License, version 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 This project includes the software: org.apache.jclouds.provider
-  Available at: http://jclouds.apache.org/
+  Available at: http://jclouds.apache.org/aws-s3/ http://jclouds.apache.org/azureblob/ http://jclouds.apache.org/rackspace-cloudfiles-us/ http://jclouds.apache.org/rackspace-cloudfiles-uk/ http://jclouds.apache.org/hpcloud-objectstorage/ http://jclouds.apache.org/aws-ec2/ http://jclouds.apache.org/gogrid/ http://jclouds.apache.org/elastichosts-lon-p/ http://jclouds.apache.org/elastichosts-sat-p/ http://jclouds.apache.org/elastichosts-lon-b/ http://jclouds.apache.org/openhosting-east1/ http://jclouds.apache.org/serverlove-z1-man/ http://jclouds.apache.org/skalicloud-sdg-my/ http://jclouds.apache.org/go2cloud-jhb1/ http://jclouds.apache.org/softlayer/ http://jclouds.apache.org/hpcloud-compute/ http://jclouds.apache.org/rackspace-cloudservers-us/ http://jclouds.apache.org/rackspace-cloudservers-uk/
   Developed by: The Apache Software Foundation (http://www.apache.org/)
   Version used: 1.9.2
   Used under the following license: Apache License, version 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -643,7 +654,7 @@ This project includes the software: org.eclipse.jetty
   Used under the following license: Apache License, version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
 
 This project includes the software: org.eclipse.jetty.toolchain
-  Available at: http://www.eclipse.org/jetty
+  Available at: http://www.eclipse.org/jetty/jetty-toolchain/jetty-schemas
   Developed by: Mort Bay Consulting (http://www.mortbay.com)
   Version used: 3.1.M0
   Used under the following license: Apache License, version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
@@ -679,7 +690,7 @@ This project includes the software: org.mongodb
   Used under the following license: Apache License, version 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 This project includes the software: org.reflections
-  Available at: http://code.google.com/p/reflections/
+  Available at: http://code.google.com/p/reflections/reflections/
   Version used: 0.9.9-RC1
   Used under the following license: WTFPL (http://www.wtfpl.net/)
 
@@ -698,6 +709,12 @@ This project includes the software: org.yaml
   Available at: http://www.snakeyaml.org
   Version used: 1.11
   Used under the following license: Apache License, version 2.0 (in-project reference: LICENSE.txt)
+
+This project includes the software: placeholder.js
+  Available at: http://codemirror.net/
+  Version used: 5.11.1
+  Used under the following license: The MIT License (http://opensource.org/licenses/MIT)
+  CodeMirror (c) Marijn Haverbeke and others
 
 This project includes the software: RequireJS
   Available at: http://requirejs.org/
@@ -732,6 +749,12 @@ This project includes the software: RequireJS (r.js maven plugin)
       Yusuke Suzuki (2012)
       Arpad Borsos (2012)
     Used under the BSD 2-Clause license.
+
+This project includes the software: show-hint.{js,css}
+  Available at: http://codemirror.net/
+  Version used: 5.11.1
+  Used under the following license: The MIT License (http://opensource.org/licenses/MIT)
+  CodeMirror (c) Marijn Haverbeke and others
 
 This project includes the software: Swagger UI
   Available at: https://github.com/swagger-api/swagger-ui
@@ -773,6 +796,12 @@ This project includes the software: xpp3
   Developed by: Extreme! Lab, Indiana University (http://www.extreme.indiana.edu/)
   Version used: 1.1.4c
   Used under the following license: Indiana University Extreme! Lab Software License, vesion 1.1.1 (https://github.com/apache/openmeetings/blob/a95714ce3f7e587d13d3d0bb3b4f570be15c67a5/LICENSE#L1361)
+
+This project includes the software: yaml.js
+  Available at: http://codemirror.net/
+  Version used: 5.11.1
+  Used under the following license: The MIT License (http://opensource.org/licenses/MIT)
+  CodeMirror (c) Marijn Haverbeke and others
 
 This project includes the software: ZeroClipboard
   Available at: http://zeroclipboard.org/


### PR DESCRIPTION
Relates to https://github.com/apache/brooklyn-ui/pull/1