### PR TITLE
switch to wily64 - vivid64 ubuntu box no longer available

### DIFF
--- a/vagrant/src/main/vagrant/servers.yaml
+++ b/vagrant/src/main/vagrant/servers.yaml
@@ -38,7 +38,7 @@ default_config:
     run_os_update: true
 servers:
   - name: brooklyn
-    box: ubuntu/vivid64
+    box: ubuntu/wily64
     ram: 2048
     cpus: 4
     ip: 10.10.10.100
@@ -52,22 +52,22 @@ servers:
         - sudo systemctl start brooklyn
         - sudo systemctl enable brooklyn
   - name: byon1
-    box: ubuntu/vivid64
+    box: ubuntu/wily64
     ram: 512
     cpus: 2
     ip: 10.10.10.101
   - name: byon2
-    box: ubuntu/vivid64
+    box: ubuntu/wily64
     ram: 512
     cpus: 2
     ip: 10.10.10.102
   - name: byon3
-    box: ubuntu/vivid64
+    box: ubuntu/wily64
     ram: 512
     cpus: 2
     ip: 10.10.10.103
   - name: byon4
-    box: ubuntu/vivid64
+    box: ubuntu/wily64
     ram: 512
     cpus: 2
     ip: 10.10.10.104


### PR DESCRIPTION
- see https://bugs.launchpad.net/ubuntu/+bug/1553119

Confirmed this stands up as expected, and deployed the Template 4: Resilient Load-Balanced Bash Web Cluster with Sensors example