### PR TITLE
AnsibleEntity was missing from 'all' pom.xml

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -60,6 +60,11 @@
         </dependency>
         <dependency>
             <groupId>org.apache.brooklyn</groupId>
+            <artifactId>brooklyn-software-cm-ansible</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.brooklyn</groupId>
             <artifactId>brooklyn-software-webapp</artifactId>
             <version>${project.version}</version>
         </dependency>


### PR DESCRIPTION
 so could not deploy ansible entities.

This permits blueprints with AnsibleEntity to deploy.

