### PR TITLE
Set RPM option to allow binaries in noarch package

### DIFF
--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -64,6 +64,9 @@
                     <requires>
                         <require>java</require>
                     </requires>
+                    <defineStatements>
+                        <defineStatement>_binaries_in_noarch_packages_terminate_build 0</defineStatement>
+                    </defineStatements>
                     <mappings>
                         <mapping>
                             <directory>/etc/brooklyn</directory>


### PR DESCRIPTION
Our RPM package is marked as `noarch`. RPM will complain if it finds architecture-specific files in `noarch` package - therefore it complains for us due to the presence of the `br` tool in multiple architectures.  This commit turns off that test.