### PR TITLE
Fix config file permissions

### DIFF
--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -68,9 +68,6 @@
                         <mapping>
                             <directory>/etc/brooklyn</directory>
                             <configuration>true</configuration>
-                            <filemode>755</filemode>
-                            <username>brooklyn</username>
-                            <groupname>brooklyn</groupname>
                             <sources>
                                 <source>
                                     <location>src/conf</location>
@@ -79,7 +76,6 @@
                         </mapping>
                         <mapping>
                             <directory>/etc/brooklyn</directory>
-                            <directoryIncluded>false</directoryIncluded>
                             <configuration>true</configuration>
                             <filemode>600</filemode>
                             <username>brooklyn</username>
@@ -92,7 +88,6 @@
                         </mapping>
                         <mapping>
                             <directory>/etc/brooklyn</directory>
-                            <directoryIncluded>false</directoryIncluded>
                             <configuration>true</configuration>
                             <filemode>644</filemode>
                             <username>brooklyn</username>


### PR DESCRIPTION
Fixing the bug with incorrect file permissions on config files in `/etc/brooklyn/` directory.