### PR TITLE
Populate catalog from bundle bom

### DIFF
--- a/archetypes/quickstart/src/brooklyn-sample/src/main/resources/catalog.bom
+++ b/archetypes/quickstart/src/brooklyn-sample/src/main/resources/catalog.bom
@@ -1,0 +1,23 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+brooklyn.catalog:
+    version: 0.10.0-SNAPSHOT # BROOKLYN_VERSION
+    items:
+    - id: com.acme.sample.brooklyn.MySample
+      item:
+        type: com.acme.sample.brooklyn.MySample


### PR DESCRIPTION
The PR adds updates to the existing jars to add a catalog.bom file that includes the details of the various entities in each.  

See https://github.com/apache/brooklyn-server/pull/80 for details; this PR depends on that one and should be merged after it.
