### PR TITLE
use host only networking for brooklyn node

### DIFF
--- a/vagrant/src/main/vagrant/Vagrantfile
+++ b/vagrant/src/main/vagrant/Vagrantfile
@@ -26,6 +26,9 @@ VAGRANTFILE_API_VERSION = "2"
 # Update OS (Debian/RedHat based only)
 UPDATE_OS_CMD = "(sudo apt-get update && sudo apt-get -y upgrade) || (sudo yum -y update)"
 
+# Autocorrect Port Clashes
+DEFAULT_AUTOCORRECT = false
+
 # Require YAML module
 require 'yaml'
 
@@ -48,8 +51,13 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       end
 
       if server.has_key?("forwarded_ports")
-        server["forwarded_ports"].each do |ports|
-          server_config.vm.network "forwarded_port", guest: ports["guest"], host: ports["host"], guest_ip: ports["guest_ip"]
+        server["forwarded_ports"].each do |port|
+          if port.has_key?("autocorrect")
+            autocorrect = true
+          else
+            autocorrect = DEFAULT_AUTOCORRECT
+          end
+          server_config.vm.network "forwarded_port", guest: port["guest"], host: port["host"], guest_ip: port["guest_ip"], autocorrect: autocorrect
         end
       end
 
@@ -74,3 +82,17 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     end
   end
 end
+
+# ALTERING PORT FORWARDING
+# If you are reading this you have likely been instructed by Vagrant to alter the example
+# line below due to the forwarded port colliding with one alread in use on your system.
+#
+#   config.vm.network :forwarded_port, guest: 80, host: 1234
+#
+# This Vagrantfile does not define the port mapping here, instead you should alter
+# the following line in the `servers.yaml` file in this directory.
+#
+#   host: 8081
+#
+# Change 8081 to a port that is not in use on your local machine before attempting
+# to run vagrant up again.

--- a/vagrant/src/main/vagrant/servers.yaml
+++ b/vagrant/src/main/vagrant/servers.yaml
@@ -44,6 +44,7 @@ servers:
     forwarded_ports:
      - guest: 8081
        host: 8081
+       autocorrect: true
     shell:
       env:
         BROOKLYN_VERSION: 0.10.0-SNAPSHOT

--- a/vagrant/src/main/vagrant/servers.yaml
+++ b/vagrant/src/main/vagrant/servers.yaml
@@ -41,7 +41,9 @@ servers:
     box: ubuntu/wily64
     ram: 2048
     cpus: 4
-    ip: 10.10.10.100
+    forwarded_ports:
+     - guest: 8081
+       host: 8081
     shell:
       env:
         BROOKLYN_VERSION: 0.10.0-SNAPSHOT


### PR DESCRIPTION
- brooklyn accessible on the local node (desktop/laptop where you have run `vagrant up`) via mapped `8081` port at `http://127.0.0.1:8081` which matches the manual install url (simplifies docs)
- can still access the byon nodes on `10.10.10.x` and avoids having to worry about subnet clashes for brooklyn itself