### PR TITLE
Don't run mvn in change-version.sh

### DIFF
--- a/release/change-version.sh
+++ b/release/change-version.sh
@@ -40,9 +40,6 @@ else
   exit 1
 fi
 
-# remove binaries and stuff
-if [ -f pom.xml ] && [ -d target ] ; then mvn clean ; fi
-
 VERSION_MARKER_NL=${VERSION_MARKER}_BELOW
 CURRENT_VERSION=$1
 NEW_VERSION=$2


### PR DESCRIPTION
`target` folders are already excluded in the find command. Remove call to `mvn clean` because the project could hit unresolved dependencies (in the case of using a custom repo location). Also speeds up the execution.