### PR TITLE
Close public ports protected by the default credentials

### DIFF
--- a/karaf/apache-brooklyn/src/main/resources/etc/org.apache.karaf.shell.cfg
+++ b/karaf/apache-brooklyn/src/main/resources/etc/org.apache.karaf.shell.cfg
@@ -1,0 +1,96 @@
+################################################################################
+#
+#    Licensed to the Apache Software Foundation (ASF) under one or more
+#    contributor license agreements.  See the NOTICE file distributed with
+#    this work for additional information regarding copyright ownership.
+#    The ASF licenses this file to You under the Apache License, Version 2.0
+#    (the "License"); you may not use this file except in compliance with
+#    the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+################################################################################
+
+#
+# These properties are used to configure Karaf's ssh shell.
+#
+
+#
+# Via sshPort and sshHost you define the address you can login into Karaf.
+#
+sshPort = 8101
+sshHost = 127.0.0.1
+
+#
+# The sshIdleTimeout defines the inactivity timeout to logout the SSH session.
+# The sshIdleTimeout is in milliseconds, and the default is set to 30 minutes.
+#
+sshIdleTimeout = 1800000
+
+#
+# sshRealm defines which JAAS domain to use for password authentication.
+#
+sshRealm = karaf
+
+#
+# The location of the hostKey file defines where the private/public key of the server
+# is located. If no file is at the defined location it will be ignored.
+#
+hostKey = ${karaf.etc}/host.key
+
+#
+# The format used for hostKey.
+# Possible values are simple (Karaf internal), or PEM (OpenSSH format)
+#
+hostKeyFormat = simple
+
+#
+# Role name used for SSH access authorization
+# If not set, this defaults to the ${karaf.admin.role} configured in etc/system.properties
+#
+# sshRole = admin
+
+#
+# Self defined key size in 1024, 2048, 3072, or 4096
+# If not set, this defaults to 4096.
+#
+# keySize = 4096
+
+#
+# Specify host key algorithm, defaults to RSA
+#
+# algorithm = RSA
+
+#
+# Specify the client log level (default is WARN)
+# 0: ERROR
+# 1: WARN
+# 2: INFO
+# 3: DEBUG
+# 4: TRACE
+#
+#logLevel=1
+
+#
+# Specify an additional welcome banner to be displayed when a user logs into the server.
+#
+# welcomeBanner =
+
+#
+# Defines the completion mode on the Karaf shell console. The possible values are:
+# - GLOBAL: it's the same behavior as in previous Karaf releases. The completion displays all commands and all aliases
+#           ignoring if you are in a subshell or not.
+# - FIRST: the completion displays all commands and all aliases only when you are not in a subshell. When you are
+#          in a subshell, the completion displays only the commands local to the subshell.
+# - SUBSHELL: the completion displays only the subshells on the root level. When you are in a subshell, the completion
+#             displays only the commands local to the subshell.
+# This property define the default value when you use the Karaf shell console.
+# You can change the completion mode directly in the shell console, using shell:completion command.
+#
+completionMode = GLOBAL

--- a/karaf/features/src/main/feature/feature.xml
+++ b/karaf/features/src/main/feature/feature.xml
@@ -21,6 +21,30 @@
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:noNamespaceSchemaLocation="http://karaf.apache.org/xmlns/features/v1.2.0">
 
+    <feature name="brooklyn-standard-karaf" version="${project.version}" description="Karaf standard feature with RMI excluded">
+        <feature>wrap</feature>
+        <feature>aries-blueprint</feature>
+        <feature>shell</feature>
+        <feature>shell-compat</feature>
+        <feature>feature</feature>
+        <feature>jaas</feature>
+        <feature>ssh</feature>
+        <!-- Don't load the feature as it opens ports protected by the default credentials -->
+        <!-- Could alternatively reconfigure the feature to use more restricted realm, but we don't use this functionality anyway. -->
+        <!-- feature>management</feature -->
+        <feature>bundle</feature>
+        <feature>config</feature>
+        <feature>deployer</feature>
+        <feature>diagnostic</feature>
+        <feature>feature</feature>
+        <feature>instance</feature>
+        <feature>kar</feature>
+        <feature>log</feature>
+        <feature>package</feature>
+        <feature>service</feature>
+        <feature>system</feature>
+    </feature>
+
     <feature name="brooklyn-startup-features" version="${project.version}" description="Bundles to add to startup.properties">
         <!-- Register javax.mail along with pax-logging-service so it doesn't get refreshed later -->
         <bundle>mvn:javax.mail/mail/${javax.mail.version}</bundle>
@@ -32,7 +56,7 @@
     </feature>
 
     <feature name="brooklyn-headless" version="${project.version}" description="All Brooklyn bundles witht the exception of the launcher">
-        <feature prerequisite="true">standard</feature>
+        <feature prerequisite="true">brooklyn-standard-karaf</feature>
         <feature prerequisite="true">brooklyn-guava-optional-deps</feature>
         <feature>brooklyn-core</feature>
         <feature>brooklyn-rest-resources</feature>


### PR DESCRIPTION
After the changes three ports remain open:
  * 8081 - web UI, password is generated on the fly if not explicitly set by the user
  * 8101 - ssh Karaf access, protected by default credentials, open to localhost only
  * random - jmx port, enabled by "-Dcom.sun.management.jmxremote" in bin/karaf, allows local access only
  * random - shutdown port