### PR TITLE
Silence Karaf dist brooklyn.info.log

### DIFF
--- a/karaf/apache-brooklyn/src/main/resources/etc/org.ops4j.pax.logging.cfg
+++ b/karaf/apache-brooklyn/src/main/resources/etc/org.ops4j.pax.logging.cfg
@@ -18,40 +18,44 @@
 ################################################################################
 
 # Root logger
-log4j.rootLogger=INFO, out, debugFile, osgi:VmLogAppender
+log4j.rootLogger=INFO, info, debug, osgi:VmLogAppender
 log4j.throwableRenderer=org.apache.log4j.OsgiThrowableRenderer
 
 # CONSOLE appender not used by default
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
-log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%d{ABSOLUTE} %-5.5p %3.3X{bundle.id} %-30.30c{2} [%-16.16t] %m%n
+log4j.appender.stdout.layout=org.apache.log4j.EnhancedPatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{ISO8601} %-5.5p %3X{bundle.id} %c{1.} [%.16t] %m%n
 
 # Info file appender
-log4j.appender.out=org.apache.log4j.RollingFileAppender
-log4j.appender.out.layout=org.apache.log4j.PatternLayout
-log4j.appender.out.layout.ConversionPattern=%d{ABSOLUTE} %-5.5p %3.3X{bundle.id} %-30.30c{2} [%-16.16t] %m%n
-log4j.appender.out.file=${karaf.home}/log/brooklyn.info.log
-log4j.appender.out.Threshold=INFO
-log4j.appender.out.append=true
-log4j.appender.out.maxFileSize=100MB
-log4j.appender.out.maxBackupIndex=10
+log4j.appender.info=org.apache.log4j.RollingFileAppender
+log4j.appender.info.layout=org.apache.log4j.EnhancedPatternLayout
+log4j.appender.info.layout.ConversionPattern=%d{ISO8601} %-5.5p %3X{bundle.id} %c{1.} [%.16t] %m%n
+log4j.appender.info.file=${karaf.home}/log/brooklyn.info.log
+log4j.appender.info.Threshold=INFO
+log4j.appender.info.append=true
+log4j.appender.info.maxFileSize=100MB
+log4j.appender.info.maxBackupIndex=10
+
+log4j.appender.infoWarn=org.apache.log4j.AsyncAppender
+log4j.appender.infoWarn.appenders=info
+log4j.appender.infoWarn.Threshold=WARN
 
 # Debug file appender
-log4j.appender.debugFile=org.apache.log4j.RollingFileAppender
-log4j.appender.debugFile.layout=org.apache.log4j.PatternLayout
-log4j.appender.debugFile.layout.ConversionPattern=%d{ABSOLUTE} %-5.5p %3.3X{bundle.id} %-30.30c{2} [%-16.16t] %m%n
-log4j.appender.debugFile.file=${karaf.home}/log/brooklyn.debug.log
-log4j.appender.debugFile.append=true
-log4j.appender.debugFile.maxFileSize=100MB
-log4j.appender.debugFile.maxBackupIndex=10
+log4j.appender.debug=org.apache.log4j.RollingFileAppender
+log4j.appender.debug.layout=org.apache.log4j.EnhancedPatternLayout
+log4j.appender.debug.layout.ConversionPattern=%d{ISO8601} %-5.5p %3X{bundle.id} %c{1.} [%.16t] %m%n
+log4j.appender.debug.file=${karaf.home}/log/brooklyn.debug.log
+log4j.appender.debug.append=true
+log4j.appender.debug.maxFileSize=100MB
+log4j.appender.debug.maxBackupIndex=10
 
 # Sift appender
 log4j.appender.sift=org.apache.log4j.sift.MDCSiftingAppender
 log4j.appender.sift.key=bundle.name
 log4j.appender.sift.default=brooklyn
 log4j.appender.sift.appender=org.apache.log4j.FileAppender
-log4j.appender.sift.appender.layout=org.apache.log4j.PatternLayout
-log4j.appender.sift.appender.layout.ConversionPattern=%d{ABSOLUTE} %-5.5p %3.3X{bundle.id} %-30.30c{2} [%-16.16t] %m%n
+log4j.appender.sift.appender.layout=org.apache.log4j.EnhancedPatternLayout
+log4j.appender.sift.appender.layout.ConversionPattern=%d{ISO8601} %-5.5p %3X{bundle.id} %c{1.} [%.16t] %m%n
 log4j.appender.sift.appender.file=${karaf.data}/log/$\\{bundle.name\\}.log
 log4j.appender.sift.appender.append=true
 
@@ -59,37 +63,66 @@ log4j.appender.sift.appender.append=true
 # Logger configuration
 
 # The following properties turn on quite verbose DEBUG logging for Brooklyn-relevant loggers
-log4j.logger.brooklyn=DEBUG
 log4j.logger.org.apache.brooklyn=DEBUG
 log4j.logger.org.jclouds=DEBUG
 log4j.logger.jclouds=DEBUG
-io.cloudsoft.winrm4j.winrm.WinRmTool=DEBUG
+log4j.io.cloudsoft.winrm4j.winrm.WinRmTool=DEBUG
 
 # If you're just going to have a few debug categories these are recommended;
 # comment out the loggers above and leave these as-is
-log4.logger.brooklyn.SSH=DEBUG
-log4.logger.brooklyn.location.basic.jclouds=DEBUG
-log4.logger.brooklyn.util.internal.ssh=DEBUG
-log4.logger.org.apache.brooklyn.SSH=DEBUG
-log4.logger.org.apache.brooklyn.location.basic.jclouds=DEBUG
-log4.logger.org.apache.brooklyn.util.internal.ssh=DEBUG
+log4j.logger.org.apache.brooklyn.SSH=DEBUG
+log4j.logger.org.apache.brooklyn.location.basic.jclouds=DEBUG
+log4j.logger.org.apache.brooklyn.util.internal.ssh=DEBUG
 
 # a bit noisy at INFO, but still, poss interesting
-log4j.logger.org.reflections.Reflections=INFO
-log4j.logger.com.sun.jersey.server.impl.application=INFO
-log4j.logger.org.apache.whirr.service.ComputeCache=INFO
-log4j.logger.jclouds.ssh=INFO
-log4j.logger.org.apache.http.impl.client=INFO
-log4j.logger.javax.management.remote=INFO
+log4j.additivity.org.reflections.Reflections=false
+log4j.logger.org.reflections.Reflections=INFO, infoWarn, debug
+
+log4j.additivity.com.sun.jersey.server.impl.application=false
+log4j.logger.com.sun.jersey.server.impl.application=INFO, infoWarn, debug
+
+log4j.additivity.org.apache.whirr.service.ComputeCache=false
+log4j.logger.org.apache.whirr.service.ComputeCache=INFO, infoWarn, debug
+
+log4j.additivity.jclouds.ssh=false
+log4j.logger.jclouds.ssh=INFO, infoWarn, debug
+
+log4j.additivity.org.apache.http.impl.client=false
+log4j.logger.org.apache.http.impl.client=INFO, infoWarn, debug
+
+log4j.additivity.javax.management.remote=false
+log4j.logger.javax.management.remote=INFO, debug
 
 # some loggers are very noisy however, exclude them
-log4j.logger.org.apache.cxf=WARN
-log4j.logger.net.schmizz=WARN
+log4j.additivity.org.apache.cxf=false
+log4j.logger.org.apache.cxf=ERROR
+
 log4j.logger.org.eclipse.jetty=WARN
-log4j.logger.org.mongodb.driver=WARN
+
+log4j.additivity.net.schmizz=false
+log4j.logger.net.schmizz=WARN, debug
+
+log4j.additivity.org.mongodb.driver=false
+log4j.logger.org.mongodb.driver=WARN, debug
 
 #  Wordnik logs errors in a few places which aren't errors at all; ignore them altogether
 # (Turn them back on if you need to see how API-doc gets generated, and also
 # see https://github.com/wordnik/swagger-core/issues/58)
 log4j.logger.com.wordnik.swagger=OFF
 
+# TODO Figure out why spi-fly is activated, we don't need it
+log4j.additivity.org.apache.aries.spifly.dynamic.bundle=false
+log4j.logger.org.apache.aries.spifly.dynamic.bundle=INFO, debug
+
+# Karaf specific
+log4j.additivity.org.apache.felix=false
+log4j.logger.org.apache.felix=INFO, infoWarn, debug
+
+log4j.additivity.org.apache.karaf=false
+log4j.logger.org.apache.karaf=INFO, infoWarn, debug
+
+log4j.additivity.org.ops4j.pax.web=false
+log4j.logger.org.ops4j.pax.web=INFO, infoWarn, debug
+
+log4j.additivity.org.apache.aries=false
+log4j.logger.org.apache.aries=INFO, infoWarn, debug


### PR DESCRIPTION
Also fix missing or invalid log4j.logger prefixes to packages, change the logging layout to be more compact (no fixed widths)