### PR TITLE
Update tests following changes in files.preinstall inheritance

### DIFF
--- a/shared-packaging/src/test/yaml/Vagrantfile
+++ b/shared-packaging/src/test/yaml/Vagrantfile
@@ -1,0 +1,51 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Example Vagrantfile for testing RPM/DEB installation on a
+# convenient Vagrant box.
+# Maps your public key to 'authorized_keys' on the vagrant.
+# see note on 'source below'.
+
+Vagrant.configure(2) do |config|
+  config.vm.provider "virtualbox" do |vb|
+    vb.memory = "1024"
+    vb.customize ["modifyvm", :id, "--nictype1", "virtio"]
+    vb.customize ["modifyvm", :id, "--nictype2", "virtio"]
+  end
+
+  # change the 'source' below if necessary to match your public key file path
+  config.vm.provision "file", source: "~/.ssh/id_rsa.pub", destination: "~/.ssh/authorized_keys"
+  config.vm.provision "shell", name:"set key permissions", privileged:false, inline: "chmod 400 ~/.ssh/authorized_keys"
+
+  config.vm.define "apt-systemd" do |config|
+    config.vm.box = "ubuntu/wily64"
+    config.vm.network "private_network", ip: "172.28.128.3"
+  end
+  config.vm.define "apt-upstart" do |config|
+    config.vm.box = "ubuntu/trusty64"
+    config.vm.network "private_network", ip: "172.28.128.4"
+  end
+  config.vm.define "yum-systemd" do |config|
+    config.vm.box = "centos/7"
+    config.vm.network "private_network", ip: "172.28.128.5"
+  end
+  config.vm.define "yum-upstart" do |config|
+    config.vm.box = "nrel/CentOS-6.5-x86_64"
+    config.vm.network "private_network", ip: "172.28.128.6"
+  end
+end

--- a/shared-packaging/src/test/yaml/package-apps.yaml
+++ b/shared-packaging/src/test/yaml/package-apps.yaml
@@ -25,8 +25,7 @@ services:
       # privateKeyFile: ~/.ssh/<private key>
       user: vagrant
   brooklyn.config:
-    files.preinstall:
-      ~/.m2/repository/org/apache/brooklyn/deb-packaging/0.10.0-SNAPSHOT/deb-packaging-0.10.0-SNAPSHOT.deb: brooklyn-package.deb # BROOKLYN_VERSION
+    package.file:  ~/.m2/repository/org/apache/brooklyn/deb-packaging/0.10.0-SNAPSHOT/deb-packaging-0.10.0-SNAPSHOT.deb # BROOKLYN_VERSION
 
 ---
 
@@ -39,8 +38,7 @@ services:
       # privateKeyFile: ~/.ssh/<private key>
       user: vagrant
   brooklyn.config:
-    files.preinstall:
-      ~/.m2/repository/org/apache/brooklyn/deb-packaging/0.10.0-SNAPSHOT/deb-packaging-0.10.0-SNAPSHOT.deb: brooklyn-package.deb # BROOKLYN_VERSION
+    package.file: ~/.m2/repository/org/apache/brooklyn/deb-packaging/0.10.0-SNAPSHOT/deb-packaging-0.10.0-SNAPSHOT.deb # BROOKLYN_VERSION
 
 ---
 
@@ -53,8 +51,7 @@ services:
       # privateKeyFile: ~/.ssh/<private key>
       user: vagrant
   brooklyn.config:
-    files.preinstall:
-      ~/.m2/repository/org/apache/brooklyn/rpm-packaging/0.10.0-SNAPSHOT/rpm-packaging-0.10.0-SNAPSHOT.rpm: brooklyn-package.rpm # BROOKLYN_VERSION
+    package.file: ~/.m2/repository/org/apache/brooklyn/rpm-packaging/0.10.0-SNAPSHOT/rpm-packaging-0.10.0-SNAPSHOT.rpm # BROOKLYN_VERSION
 
 ---
 
@@ -67,37 +64,6 @@ services:
       # privateKeyFile: ~/.ssh/<private key>
       user: vagrant
   brooklyn.config:
-    files.preinstall:
-      ~/.m2/repository/org/apache/brooklyn/rpm-packaging/0.10.0-SNAPSHOT/rpm-packaging-0.10.0-SNAPSHOT.rpm: brooklyn-package.rpm # BROOKLYN_VERSION
+    package.file: ~/.m2/repository/org/apache/brooklyn/rpm-packaging/0.10.0-SNAPSHOT/rpm-packaging-0.10.0-SNAPSHOT.rpm # BROOKLYN_VERSION
 
 
----
-
-# Vagrantfile
-Vagrant.configure(2) do |config|
-  config.vm.provider "virtualbox" do |vb|
-    vb.memory = "1024"
-    vb.customize ["modifyvm", :id, "--nictype1", "virtio"]
-    vb.customize ["modifyvm", :id, "--nictype2", "virtio"]
-  end
-  config.vm.provision "shell", privileged: false, inline: <<-SHELL
-    echo "<REPLACE public key fingerprint>" >> ~/.ssh/authorized_keys
-  SHELL
-
-  config.vm.define "apt-systemd" do |config|
-    config.vm.box = "ubuntu/wily64"
-    config.vm.network "private_network", ip: "172.28.128.3"
-  end
-  config.vm.define "apt-upstart" do |config|
-    config.vm.box = "ubuntu/trusty64"
-    config.vm.network "private_network", ip: "172.28.128.4"
-  end
-  config.vm.define "yum-systemd" do |config|
-    config.vm.box = "centos/7"
-    config.vm.network "private_network", ip: "172.28.128.5"
-  end
-  config.vm.define "yum-upstart" do |config|
-    config.vm.box = "nrel/CentOS-6.5-x86_64"
-    config.vm.network "private_network", ip: "172.28.128.6"
-  end
-end

--- a/shared-packaging/src/test/yaml/package.bom
+++ b/shared-packaging/src/test/yaml/package.bom
@@ -18,22 +18,8 @@
 #
 brooklyn.catalog:
   version: "0.10.0-SNAPSHOT"  # BROOKLYN_VERSION
-### brooklyn install entities ###
-  apt-config: &apt-config
-    install.command: |
-      sudo apt-get update
-      sudo apt-get install -y default-jre-headless
-      sudo dpkg -i brooklyn-package.deb
-  yum-config: &yum-config
-    install.command: |
-      if sudo iptables -L | grep REJECT; then
-        # Only for CentOS 6
-        sudo iptables -I INPUT -p tcp -m tcp --dport 8081 -j ACCEPT
-        sudo service iptables save
-      fi
-      sudo yum -y install java-1.7.0-openjdk.x86_64
-      sudo yum -y install brooklyn-package.rpm
   items:
+
   - id: systemd-brooklyn
     item:
       type: org.apache.brooklyn.entity.software.base.VanillaSoftwareProcess
@@ -44,6 +30,7 @@ brooklyn.catalog:
           sudo systemctl status brooklyn
         stop.command: |
           sudo systemctl stop brooklyn
+
   - id: upstart-brooklyn
     item:
       type: org.apache.brooklyn.entity.software.base.VanillaSoftwareProcess
@@ -54,26 +41,64 @@ brooklyn.catalog:
           sudo status brooklyn | grep running
         stop.command: |
           sudo stop brooklyn
+
   - id: apt-systemd-brooklyn
     item:
       type: systemd-brooklyn
       id: brooklyn
-      brooklyn.config: *apt-config
+      brooklyn.config:
+        files.preinstall:
+          $brooklyn:config("package.file") : brooklyn-package.deb
+        install.command: |
+          sudo apt-get update
+          sudo apt-get install -y default-jre-headless
+          sudo dpkg -i brooklyn-package.deb
+
   - id: apt-upstart-brooklyn
     item:
       type: upstart-brooklyn
       id: brooklyn
-      brooklyn.config: *apt-config
+      brooklyn.config:
+        files.preinstall:
+          $brooklyn:config("package.file"): brooklyn-package.deb
+        install.command: |
+          sudo apt-get update
+          sudo apt-get install -y default-jre-headless
+          sudo dpkg -i brooklyn-package.deb
+
   - id: yum-systemd-brooklyn
     item:
       type: systemd-brooklyn
       id: brooklyn
-      brooklyn.config: *yum-config
+      brooklyn.config:
+        files.preinstall:
+          $brooklyn:config("package.file"): brooklyn-package.rpm
+        install.command: |
+          if sudo iptables -L | grep REJECT; then
+            # Only for CentOS 6
+            sudo iptables -I INPUT -p tcp -m tcp --dport 8081 -j ACCEPT
+            sudo service iptables save
+          fi
+          sudo yum -y install java-1.7.0-openjdk.x86_64
+          sudo yum -y install brooklyn-package.rpm
+
   - id: yum-upstart-brooklyn
     item:
       type: upstart-brooklyn
       id: brooklyn
-      brooklyn.config: *yum-config
+      brooklyn.config:
+        files.preinstall:
+          $brooklyn:config("package.file") : brooklyn-package.rpm
+        install.command: |
+          if sudo iptables -L | grep REJECT; then
+            # Only for CentOS 6
+            sudo iptables -I INPUT -p tcp -m tcp --dport 8081 -j ACCEPT
+            sudo service iptables save
+          fi
+          sudo yum -y install java-1.7.0-openjdk.x86_64
+          sudo yum -y install brooklyn-package.rpm
+
+
 ### Tests ###
   - id: test-is-up
     item:


### PR DESCRIPTION
Need to update the tests following changes in inheritance
of files.preinstall, see https://github.com/apache/brooklyn-server/pull/281.

This allows the tests defined in package-apps.yaml to work again.  

Caveat: in the apt-upstart test on my machine, the `13. restart machine` step happens so quickly that Brooklyn doesn't even notice that the Vanilla Software Process has gone down, so the step `14. check not running while restarting' fails. Not sure what to do about that; however I have manually tested that Brooklyn comes up again after the restart.