### PR TITLE
Suppress log message about BouncyCastle in Karaf

### DIFF
--- a/karaf/apache-brooklyn/src/main/resources/etc/system.properties
+++ b/karaf/apache-brooklyn/src/main/resources/etc/system.properties
@@ -134,6 +134,9 @@ karaf.secured.services = (&(osgi.command.scope=*)(osgi.command.function=*))
 
 #
 # Explicitly prevent Karaf's sshd from registering BouncyCastle
-# to suppress misleading message in the log
+# to suppress misleading message in the log.
+#
+# TODO: We have BouncyCastle but it's an older version than the one org.apache.sshd
+# requires (1.49 vs 1.51). Once we update our dependency version we should revisit this.
 #
 org.apache.sshd.registerBouncyCastle = false

--- a/karaf/apache-brooklyn/src/main/resources/etc/system.properties
+++ b/karaf/apache-brooklyn/src/main/resources/etc/system.properties
@@ -131,3 +131,9 @@ karaf.secured.services = (&(osgi.command.scope=*)(osgi.command.function=*))
 # You can specify the location of the lock file using the
 # karaf.lock.dir=/path/to/the/directory/containing/the/lock
 #
+
+#
+# Explicitly prevent Karaf's sshd from registering BouncyCastle
+# to suppress misleading message in the log
+#
+org.apache.sshd.registerBouncyCastle = false


### PR DESCRIPTION
 The INFO message `BouncyCastle not registered, using the default JCE provider`
 appears in the logs, coming from Karaf's SSH server module (org.apache.sshd.core).
 Explicitly prevent sshd from registering BC to suppress the message.