### PR TITLE
Make archetypeRepository configurable

### DIFF
--- a/archetypes/quickstart/pom.xml
+++ b/archetypes/quickstart/pom.xml
@@ -180,6 +180,7 @@
                 <replacement> <token>\$</token> <value>\\\$</value> </replacement>
                 -->
                 
+                <replacement> <token>brooklyn-sample-extra-repo-url</token> <value>\$\{archetypeRepository}</value> </replacement>
                 <replacement> <token>brooklyn-sample</token> <value>\$\{artifactId}</value> </replacement>
                 <replacement> <token>com\.acme\.sample\.brooklyn</token> <value>\$\{package}</value> </replacement>
                 <replacement> <token>com/acme/sample/brooklyn</token> <value>\$\{packageInPathFormat}</value> </replacement>

--- a/archetypes/quickstart/src/brooklyn-sample/pom.xml
+++ b/archetypes/quickstart/src/brooklyn-sample/pom.xml
@@ -47,6 +47,11 @@
 
   <repositories>
     <repository>
+      <id>extra.repo</id>
+      <name>Extra Repository</name>
+      <url>brooklyn-sample-extra-repo-url</url> 
+    </repository>
+    <repository>
       <id>apache.snapshots</id>
       <name>Apache Snapshot Repository</name>
       <url>http://repository.apache.org/snapshots</url>

--- a/archetypes/quickstart/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/archetypes/quickstart/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -20,6 +20,12 @@
 <archetype xmlns="http://maven.apache.org/plugins/maven-archetype-plugin/archetype/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/plugins/maven-archetype-plugin/archetype/1.0.0 http://maven.apache.org/xsd/archetype-1.0.0.xsd">
 
+  <requiredProperties>
+    <requiredProperty key="archetypeRepository">
+      <defaultValue>https://repository.apache.org/content/repositories/releases</defaultValue>
+    </requiredProperty>
+  </requiredProperties>
+
   <fileSets>
     <fileSet filtered="true" packaged="true">
       <directory>src/main/java</directory>

--- a/archetypes/quickstart/src/test/resources/projects/integration-test-1/archetype.properties
+++ b/archetypes/quickstart/src/test/resources/projects/integration-test-1/archetype.properties
@@ -20,3 +20,4 @@ groupId=com.acme.sample
 artifactId=brooklyn-sample
 version=0.1.0-SNAPSHOT
 package=com.acme.sample.brooklyn
+archetypeRepository=brooklyn-sample-extra-repo-url


### PR DESCRIPTION
If archetypeRepository is set when using the quickstart archetype,
then add that URL to the pom.xml. This allows a customer’s private
maven artifactory to be used for accessing timestamped builds of
Brooklyn (for example).