### PR TITLE
Fix archetype test on Windows.

### DIFF
--- a/archetypes/quickstart/pom.xml
+++ b/archetypes/quickstart/pom.xml
@@ -120,6 +120,7 @@
               <outputDir>src/main/resources/archetype-resources/src/main/java</outputDir>
               <includes> <include>**/*</include> </includes>
               <replacements>
+                <replacement> <token>extra://brooklyn-sample-extra-repo-url</token> <value>\$\{archetypeRepository}</value> </replacement>
                 <replacement> <token>brooklyn-sample</token> <value>\$\{artifactId}</value> </replacement>
                 <replacement> <token>com\.acme\.sample\.brooklyn</token> <value>\$\{package}</value> </replacement>
                 <replacement> <token>com/acme/sample/brooklyn</token> <value>\$\{packageInPathFormat}</value> </replacement>
@@ -139,6 +140,7 @@
               <outputDir>src/main/resources/archetype-resources/src/test/java</outputDir>
               <includes> <include>**/*</include> </includes>
               <replacements>
+                <replacement> <token>extra://brooklyn-sample-extra-repo-url</token> <value>\$\{archetypeRepository}</value> </replacement>
                 <replacement> <token>brooklyn-sample</token> <value>\$\{artifactId}</value> </replacement>
                 <replacement> <token>com\.acme\.sample\.brooklyn</token> <value>\$\{package}</value> </replacement>
                 <replacement> <token>com/acme/sample/brooklyn</token> <value>\$\{packageInPathFormat}</value> </replacement>
@@ -180,7 +182,7 @@
                 <replacement> <token>\$</token> <value>\\\$</value> </replacement>
                 -->
                 
-                <replacement> <token>brooklyn-sample-extra-repo-url</token> <value>\$\{archetypeRepository}</value> </replacement>
+                <replacement> <token>extra://brooklyn-sample-extra-repo-url</token> <value>\$\{archetypeRepository}</value> </replacement>
                 <replacement> <token>brooklyn-sample</token> <value>\$\{artifactId}</value> </replacement>
                 <replacement> <token>com\.acme\.sample\.brooklyn</token> <value>\$\{package}</value> </replacement>
                 <replacement> <token>com/acme/sample/brooklyn</token> <value>\$\{packageInPathFormat}</value> </replacement>

--- a/archetypes/quickstart/src/brooklyn-sample/pom.xml
+++ b/archetypes/quickstart/src/brooklyn-sample/pom.xml
@@ -49,7 +49,7 @@
     <repository>
       <id>extra.repo</id>
       <name>Extra Repository</name>
-      <url>brooklyn-sample-extra-repo-url</url> 
+      <url>extra://brooklyn-sample-extra-repo-url</url>
     </repository>
     <repository>
       <id>apache.snapshots</id>

--- a/archetypes/quickstart/src/test/resources/projects/integration-test-1/archetype.properties
+++ b/archetypes/quickstart/src/test/resources/projects/integration-test-1/archetype.properties
@@ -20,4 +20,4 @@ groupId=com.acme.sample
 artifactId=brooklyn-sample
 version=0.1.0-SNAPSHOT
 package=com.acme.sample.brooklyn
-archetypeRepository=brooklyn-sample-extra-repo-url
+archetypeRepository=extra://brooklyn-sample-extra-repo-url


### PR DESCRIPTION
Fixes the following test error on windows:
```
[INFO] [ERROR] Failed to execute goal org.apache.maven.plugins:maven-remote-resources-plugin:1.5:process (default) on project brooklyn-sample: Execution default of goal org.apache.maven.plugins:maven-remote-resources-plugin:1.5:process failed: Target host is null -> [Help 1]
[INFO] org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.apache.maven.plugins:maven-remote-resources-plugin:1.5:process (default) on project brooklyn-sample: Execution default of goal org.apache.maven.plugins:maven-remote-resources-plugin:1.5:process failed: Target host is null
[INFO] 	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:224)
[INFO] 	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:153)
[INFO] 	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:145)
[INFO] 	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:108)
[INFO] 	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:76)
[INFO] 	at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build(SingleThreadedBuilder.java:51)
[INFO] 	at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:116)
[INFO] 	at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:361)
[INFO] 	at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:155)
[INFO] 	at org.apache.maven.cli.MavenCli.execute(MavenCli.java:584)
[INFO] 	at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:213)
[INFO] 	at org.apache.maven.cli.MavenCli.main(MavenCli.java:157)
[INFO] 	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[INFO] 	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
[INFO] 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[INFO] 	at java.lang.reflect.Method.invoke(Method.java:601)
[INFO] 	at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:289)
[INFO] 	at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:229)
[INFO] 	at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:415)
[INFO] 	at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:356)
[INFO] Caused by: org.apache.maven.plugin.PluginExecutionException: Execution default of goal org.apache.maven.plugins:maven-remote-resources-plugin:1.5:process failed: Target host is null
[INFO] 	at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:144)
[INFO] 	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:208)
[INFO] 	... 19 more
[INFO] Caused by: java.lang.IllegalStateException: Target host is null
[INFO] 	at org.apache.maven.wagon.providers.http.httpclient.util.Asserts.notNull(Asserts.java:46)
[INFO] 	at org.apache.maven.wagon.providers.http.httpclient.impl.client.InternalHttpClient.determineRoute(InternalHttpClient.java:125)
[INFO] 	at org.apache.maven.wagon.providers.http.httpclient.impl.client.InternalHttpClient.doExecute(InternalHttpClient.java:185)
[INFO] 	at org.apache.maven.wagon.providers.http.httpclient.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:82)
[INFO] 	at org.apache.maven.wagon.providers.http.AbstractHttpClientWagon.execute(AbstractHttpClientWagon.java:756)
[INFO] 	at org.apache.maven.wagon.providers.http.AbstractHttpClientWagon.fillInputData(AbstractHttpClientWagon.java:854)
[INFO] 	at org.apache.maven.wagon.StreamWagon.getInputStream(StreamWagon.java:116)
[INFO] 	at org.apache.maven.wagon.StreamWagon.getIfNewer(StreamWagon.java:88)
[INFO] 	at org.apache.maven.wagon.StreamWagon.get(StreamWagon.java:61)
[INFO] 	at org.apache.maven.repository.legacy.DefaultWagonManager.getRemoteFile(DefaultWagonManager.java:383)
[INFO] 	at org.apache.maven.repository.legacy.DefaultWagonManager.getArtifactMetadata(DefaultWagonManager.java:215)
[INFO] 	at org.apache.maven.artifact.repository.metadata.DefaultRepositoryMetadataManager.resolve(DefaultRepositoryMetadataManager.java:135)
[INFO] 	at org.apache.maven.project.artifact.MavenMetadataSource.retrieveAvailableVersions(MavenMetadataSource.java:435)
[INFO] 	at org.apache.maven.repository.legacy.resolver.DefaultLegacyArtifactCollector.recurse(DefaultLegacyArtifactCollector.java:497)
[INFO] 	at org.apache.maven.repository.legacy.resolver.DefaultLegacyArtifactCollector.recurse(DefaultLegacyArtifactCollector.java:584)
[INFO] 	at org.apache.maven.repository.legacy.resolver.DefaultLegacyArtifactCollector.recurse(DefaultLegacyArtifactCollector.java:584)
[INFO] 	at org.apache.maven.repository.legacy.resolver.DefaultLegacyArtifactCollector.recurse(DefaultLegacyArtifactCollector.java:584)
[INFO] 	at org.apache.maven.repository.legacy.resolver.DefaultLegacyArtifactCollector.recurse(DefaultLegacyArtifactCollector.java:584)
[INFO] 	at org.apache.maven.repository.legacy.resolver.DefaultLegacyArtifactCollector.collect(DefaultLegacyArtifactCollector.java:144)
[INFO] 	at org.apache.maven.artifact.resolver.DefaultArtifactResolver.resolve(DefaultArtifactResolver.java:494)
[INFO] 	at org.apache.maven.artifact.resolver.DefaultArtifactResolver.resolveWithExceptions(DefaultArtifactResolver.java:350)
[INFO] 	at org.apache.maven.artifact.resolver.DefaultArtifactResolver.resolveTransitively(DefaultArtifactResolver.java:344)
[INFO] 	at org.apache.maven.artifact.resolver.DefaultArtifactResolver.resolveTransitively(DefaultArtifactResolver.java:319)
[INFO] 	at org.apache.maven.artifact.resolver.DefaultArtifactResolver.resolveTransitively(DefaultArtifactResolver.java:288)
[INFO] 	at org.apache.maven.shared.artifact.resolver.DefaultProjectDependenciesResolver.resolve(DefaultProjectDependenciesResolver.java:140)
[INFO] 	at org.apache.maven.shared.artifact.resolver.DefaultProjectDependenciesResolver.resolve(DefaultProjectDependenciesResolver.java:187)
[INFO] 	at org.apache.maven.plugin.resources.remote.ProcessRemoteResourcesMojo.resolveProjectArtifacts(ProcessRemoteResourcesMojo.java:721)
[INFO] 	at org.apache.maven.plugin.resources.remote.ProcessRemoteResourcesMojo.getProjects(ProcessRemoteResourcesMojo.java:624)
[INFO] 	at org.apache.maven.plugin.resources.remote.ProcessRemoteResourcesMojo.configureVelocityContext(ProcessRemoteResourcesMojo.java:1009)
[INFO] 	at org.apache.maven.plugin.resources.remote.ProcessRemoteResourcesMojo.execute(ProcessRemoteResourcesMojo.java:513)
[INFO] 	at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:133)
[INFO] 	... 20 more
[INFO] [ERROR] 
[INFO] [ERROR] Re-run Maven using the -X switch to enable full debug logging.
[INFO] [ERROR] 
[INFO] [ERROR] For more information about the errors and possible solutions, please read the following articles:
[INFO] [ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/PluginExecutionException
[INFO] Post-archetype-generation invoker exit code: 1
```


Also adds the replacement token to all configurations for consistency.