### PR TITLE
archetype’s catalog.bom set up as 0.1.0-SNAPSHOT

### DIFF
--- a/archetypes/quickstart/pom.xml
+++ b/archetypes/quickstart/pom.xml
@@ -240,6 +240,7 @@
                 <exclude>**/src/brooklyn-sample/README.md</exclude>
                 <exclude>**/src/brooklyn-sample/pom.xml</exclude>
                 <exclude>**/src/brooklyn-sample/src/main/java/**/*.java</exclude>
+                <exclude>**/src/brooklyn-sample/src/main/resources/**/*.bom</exclude>
                 <exclude>**/src/brooklyn-sample/src/test/resources/**/*.bom</exclude>
                 <exclude>**/src/brooklyn-sample/src/test/resources/**/*.yaml</exclude>
                 <exclude>**/src/brooklyn-sample/src/test/java/**/*.java</exclude>

--- a/archetypes/quickstart/src/brooklyn-sample/src/main/resources/catalog.bom
+++ b/archetypes/quickstart/src/brooklyn-sample/src/main/resources/catalog.bom
@@ -1,22 +1,5 @@
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
-
 brooklyn.catalog:
-    version: "0.10.0-SNAPSHOT" # BROOKLYN_VERSION
+    version: "0.1.0-SNAPSHOT"
     itemType: entity
     items:
     - id: com.acme.sample.brooklyn.MySample


### PR DESCRIPTION
Previously was 0.10.0-SNAPSHOT, but this is the version of the user’s
project rather than brooklyn.

Also removes the apache header because this is a starting point for
a user to create their own projects (which will not necessarily be
apache licensed). This starting file is extremely basic; it is a file
without any degree of creativity.