### PR TITLE
Added setenv script to karaf bin 

### DIFF
--- a/karaf/apache-brooklyn/src/main/resources/bin/setenv
+++ b/karaf/apache-brooklyn/src/main/resources/bin/setenv
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# Brooklyn
+#
+
+# use default memory settings, if not specified
+if [ -z "${JAVA_MAX_MEM}" ] ; then
+    export JAVA_MAX_MEM="2G"
+fi
+if [ -z "${JAVA_MAX_PERM_MEM}" ] ; then
+    export JAVA_MAX_PERM_MEM="256m"
+fi
+
+# abort if java is not installed
+if [ "x$JAVA" = "x" ]; then
+    if [ "x$JAVA_HOME" != "x" ]; then
+        if [ ! -d "$JAVA_HOME" ]; then
+            echo "Aborting: JAVA_HOME is not valid: $JAVA_HOME"
+            exit 1
+        fi
+        JAVA="$JAVA_HOME/bin/java"
+    else
+        echo "JAVA_HOME not set; results may vary"
+        JAVA=`type java`
+        JAVA=`expr "$JAVA" : '.* \(/.*\)$'`
+        if [ "x$JAVA" = "x" ]; then
+            echo "Aborting: java command not found"
+            exit 1
+        fi
+    fi
+fi
+
+# force resolution of localhost to be loopback
+export EXTRA_JAVA_OPTS="-Dbrooklyn.location.localhost.address=127.0.0.1 ${EXTRA_JAVA_OPTS}"

--- a/karaf/apache-brooklyn/src/main/resources/bin/setenv
+++ b/karaf/apache-brooklyn/src/main/resources/bin/setenv
@@ -1,23 +1,19 @@
-#!/usr/bin/env bash
+#!/bin/sh
 #
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
+#    Licensed to the Apache Software Foundation (ASF) under one or more
+#    contributor license agreements.  See the NOTICE file distributed with
+#    this work for additional information regarding copyright ownership.
+#    The ASF licenses this file to You under the Apache License, Version 2.0
+#    (the "License"); you may not use this file except in compliance with
+#    the License.  You may obtain a copy of the License at
 #
-#  http://www.apache.org/licenses/LICENSE-2.0
+#       http://www.apache.org/licenses/LICENSE-2.0
 #
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
-#
-# Brooklyn
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
 #
 
 # use default memory settings, if not specified


### PR DESCRIPTION
This PR does the following:
- adds a `setenv` script
- sets default memory settings
- checks if java is installed
- sets the local loopback

This PR addresses the following issue https://issues.apache.org/jira/browse/BROOKLYN-348
and ensures karaf scripts don't fail silently if java is not installed.