### PR TITLE
Adds OS check to the setenv script

### DIFF
--- a/karaf/apache-brooklyn/src/main/resources/bin/setenv
+++ b/karaf/apache-brooklyn/src/main/resources/bin/setenv
@@ -24,7 +24,39 @@ if [ -z "${JAVA_MAX_PERM_MEM}" ] ; then
     export JAVA_MAX_PERM_MEM="256m"
 fi
 
+# OS specific support (must be 'true' or 'false').
+    cygwin=false;
+    darwin=false;
+    aix=false;
+    os400=false;
+    case "`uname`" in
+        CYGWIN*)
+            cygwin=true
+            ;;
+        Darwin*)
+            darwin=true
+            ;;
+        AIX*)
+            aix=true
+            ;;
+        OS400*)
+            os400=true
+            ;;
+    esac
+
 # abort if java is not installed
+if $cygwin ; then
+    [ -n "$JAVA" ] && JAVA=`cygpath --unix "$JAVA"`
+    [ -n "$JAVA_HOME" ] && JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
+fi
+
+if [ "x$JAVA_HOME" = "x" ] && [ "$darwin" = "true" ]; then
+    JAVA_HOME="$(/usr/libexec/java_home -v 1.8)"
+fi
+if [ "x$JAVA" = "x" ] && [ -r /etc/gentoo-release ] ; then
+    JAVA_HOME=`java-config --jre-home`
+fi
+
 if [ "x$JAVA" = "x" ]; then
     if [ "x$JAVA_HOME" != "x" ]; then
         if [ ! -d "$JAVA_HOME" ]; then


### PR DESCRIPTION
This PR does the following:
- Adds an OS check to the start of the `setenv` script
- Constructs `JAVA_HOME` based on the OS