### PR TITLE
Adds SoftRefLRUPolicyMSPerMB

### DIFF
--- a/dist/src/main/dist/bin/brooklyn
+++ b/dist/src/main/dist/bin/brooklyn
@@ -46,6 +46,9 @@ export INITIAL_CLASSPATH
 # TODO should be changed in code
 JAVA_OPTS="-Dbrooklyn.location.localhost.address=127.0.0.1 ${JAVA_OPTS}"
 
+# Increase garbage collection, see https://issues.apache.org/jira/browse/BROOKLYN-375
+JAVA_OPTS="-XX:SoftRefLRUPolicyMSPerMB=1 ${JAVA_OPTS}"
+
 # start Brooklyn
 echo $$ > "$ROOT/pid_java"
 if [[ -n "$JAVA_HOME" && -d "$JAVA_HOME" ]] ; then

--- a/dist/src/main/dist/bin/brooklyn.bat
+++ b/dist/src/main/dist/bin/brooklyn.bat
@@ -75,6 +75,7 @@ IF NOT "%BROOKLYN_CLASSPATH%"=="" SET "INITIAL_CLASSPATH=%BROOKLYN_CLASSPATH%;%I
 REM force resolution of localhost to be loopback, otherwise we hit problems
 REM TODO should be changed in code
 SET JAVA_OPTS=-Dbrooklyn.location.localhost.address=127.0.0.1 %JAVA_OPTS%
+SET JAVA_OPTS=-XX:SoftRefLRUPolicyMSPerMB=1 %JAVA_OPTS%
 
 REM workaround for http://bugs.sun.com/view_bug.do?bug_id=4787931
 SET JAVA_OPTS=-Duser.home="%USERPROFILE%" %JAVA_OPTS%

--- a/karaf/apache-brooklyn/src/main/resources/bin/setenv
+++ b/karaf/apache-brooklyn/src/main/resources/bin/setenv
@@ -77,3 +77,6 @@ fi
 
 # force resolution of localhost to be loopback
 export EXTRA_JAVA_OPTS="-Dbrooklyn.location.localhost.address=127.0.0.1 ${EXTRA_JAVA_OPTS}"
+
+# Increase garbage collection, see https://issues.apache.org/jira/browse/BROOKLYN-375
+export EXTRA_JAVA_OPTS="-XX:SoftRefLRUPolicyMSPerMB=1 ${EXTRA_JAVA_OPTS}"

--- a/shared-packaging/src/main/resources/service/systemd/brooklyn.service
+++ b/shared-packaging/src/main/resources/service/systemd/brooklyn.service
@@ -22,7 +22,7 @@ Documentation=https://brooklyn.apache.org/documentation/index.html
 [Service]
 Type=simple
 WorkingDirectory=/opt/brooklyn/
-Environment="JAVA_OPTS=-Dbrooklyn.location.localhost.address=127.0.0.1 -Dlogback.configurationFile=/etc/brooklyn/logback.xml -Xms256m -Xmx1g -XX:MaxPermSize=256m"
+Environment="JAVA_OPTS=-Dbrooklyn.location.localhost.address=127.0.0.1 -XX:SoftRefLRUPolicyMSPerMB=1 -Dlogback.configurationFile=/etc/brooklyn/logback.xml -Xms256m -Xmx1g -XX:MaxPermSize=256m"
 Environment="CLASSPATH=/opt/brooklyn/conf:/opt/brooklyn/lib/patch/*:/opt/brooklyn/lib/brooklyn/*:/opt/brooklyn/lib/dropins/*"
 ExecStart=/usr/bin/java $JAVA_OPTS -cp "$CLASSPATH" org.apache.brooklyn.cli.Main launch --noGlobalBrooklynProperties --localBrooklynProperties /etc/brooklyn/brooklyn.conf --persist auto
 Restart=always

--- a/shared-packaging/src/main/resources/service/upstart/deb/brooklyn.conf
+++ b/shared-packaging/src/main/resources/service/upstart/deb/brooklyn.conf
@@ -34,7 +34,7 @@ end script
 
 script
     BROOKLYN_HOME="/opt/brooklyn/"
-    JAVA_OPTS="-Dbrooklyn.location.localhost.address=127.0.0.1 -Dlogback.configurationFile=/etc/brooklyn/logback.xml -Xms256m -Xmx1g -XX:MaxPermSize=256m"
+    JAVA_OPTS="-Dbrooklyn.location.localhost.address=127.0.0.1 -XX:SoftRefLRUPolicyMSPerMB=1 -Dlogback.configurationFile=/etc/brooklyn/logback.xml -Xms256m -Xmx1g -XX:MaxPermSize=256m"
     CLASSPATH="/opt/brooklyn/conf:/opt/brooklyn/lib/patch/*:/opt/brooklyn/lib/brooklyn/*:/opt/brooklyn/lib/dropins/*"
     export BROOKLYN_HOME
     exec java ${JAVA_OPTS} -cp "${CLASSPATH}" org.apache.brooklyn.cli.Main launch --noGlobalBrooklynProperties --localBrooklynProperties /etc/brooklyn/brooklyn.conf --persist auto

--- a/shared-packaging/src/main/resources/service/upstart/rpm/brooklyn.conf
+++ b/shared-packaging/src/main/resources/service/upstart/rpm/brooklyn.conf
@@ -31,7 +31,7 @@ end script
 
 script
     BROOKLYN_HOME="/opt/brooklyn/"
-    JAVA_OPTS="-Dbrooklyn.location.localhost.address=127.0.0.1 -Dlogback.configurationFile=/etc/brooklyn/logback.xml -Xms256m -Xmx1g -XX:MaxPermSize=256m"
+    JAVA_OPTS="-Dbrooklyn.location.localhost.address=127.0.0.1 -XX:SoftRefLRUPolicyMSPerMB=1 -Dlogback.configurationFile=/etc/brooklyn/logback.xml -Xms256m -Xmx1g -XX:MaxPermSize=256m"
     CLASSPATH="/opt/brooklyn/conf:/opt/brooklyn/lib/patch/*:/opt/brooklyn/lib/brooklyn/*:/opt/brooklyn/lib/dropins/*"
     export BROOKLYN_HOME
     # Upstart is too old on CentOS 6, at least v1.4 required to use setuid, setgid.


### PR DESCRIPTION
Adds the java opt `-XX:SoftRefLRUPolicyMSPerMB=1` when launching brooklyn. see [BROOKLYN-375](https://issues.apache.org/jira/browse/BROOKLYN-375) for further details.