### PR TITLE
Upgrade rat plugin version

### DIFF
--- a/karaf/pom.xml
+++ b/karaf/pom.xml
@@ -153,7 +153,10 @@
                 <plugin>
                     <groupId>org.apache.rat</groupId>
                     <artifactId>apache-rat-plugin</artifactId>
+                    <!-- Overrides 0.11 from parent. Remove when parent catches up. -->
+                    <version>0.12</version>
                     <configuration>
+                        <consoleOutput>true</consoleOutput>
                         <excludes combine.children="append">
                             <!-- Exclude sandbox because not part of distribution: not in tgz, and not uploaded to maven-central -->
                             <exclude>sandbox/**</exclude>


### PR DESCRIPTION
Version 0.12 adds the option to dump licence violations to the console.