### PR TITLE
Upgrade karaf-maven-plugin to avoid double User-Agent bug

### DIFF
--- a/karaf/apache-brooklyn/pom.xml
+++ b/karaf/apache-brooklyn/pom.xml
@@ -120,7 +120,7 @@
       <plugin>
         <groupId>org.apache.karaf.tooling</groupId>
         <artifactId>karaf-maven-plugin</artifactId>
-        <version>${karaf.version}</version>
+        <version>${karaf.plugin.version}</version>
         <extensions>true</extensions>
         <configuration>
           <installedFeatures>

--- a/karaf/features/pom.xml
+++ b/karaf/features/pom.xml
@@ -38,7 +38,7 @@
             <plugin>
                 <groupId>org.apache.karaf.tooling</groupId>
                 <artifactId>karaf-maven-plugin</artifactId>
-                <version>${karaf.version}</version>
+                <version>${karaf.plugin.version}</version>
                 <extensions>true</extensions>
             </plugin>
         </plugins>

--- a/karaf/pom.xml
+++ b/karaf/pom.xml
@@ -40,6 +40,11 @@
     <properties>
         <!-- TODO: duplicates in brooklyn-server/karaf/pom.xml -->
         <karaf.version>4.0.4</karaf.version>
+        <!--
+            Fixes double User-Agent issue leading to split Nexus repo.
+            Caused by karaf-maven-plugin depending on wagon-http 2.8 having the bug.
+         -->
+        <karaf.plugin.version>4.0.6</karaf.plugin.version>
         <logback.version>1.0.7</logback.version>
         <org.osgi.core.version>6.0.0</org.osgi.core.version>
         <geronimo-jta_1.1_spec.version>1.1.1</geronimo-jta_1.1_spec.version>


### PR DESCRIPTION
Depends on https://github.com/apache/brooklyn-server/pull/479. See it for a detailed description.