### PR TITLE
Replace expired ubuntu default

### DIFF
--- a/vagrant/src/main/vagrant/files/brooklyn.service
+++ b/vagrant/src/main/vagrant/files/brooklyn.service
@@ -22,11 +22,11 @@ Description=Apache Brooklyn service
 Documentation=http://brooklyn.apache.org/documentation/index.html
 
 [Service]
-ExecStart=/home/vagrant/apache-brooklyn/bin/brooklyn launch --persist auto --persistenceDir /vagrant/brooklyn-persisted-state --catalogAdd /vagrant/files/vagrant-catalog.bom
-WorkingDirectory=/home/vagrant/apache-brooklyn
+ExecStart=/home/ubuntu/apache-brooklyn/bin/brooklyn launch --persist auto --persistenceDir /vagrant/brooklyn-persisted-state --catalogAdd /vagrant/files/vagrant-catalog.bom
+WorkingDirectory=/home/ubuntu/apache-brooklyn
 Restart=on-abort
-User=vagrant
-Group=vagrant
+User=ubuntu
+Group=ubuntu
 
 [Install]
 WantedBy=multi-user.target

--- a/vagrant/src/main/vagrant/files/brooklyn.service
+++ b/vagrant/src/main/vagrant/files/brooklyn.service
@@ -22,11 +22,11 @@ Description=Apache Brooklyn service
 Documentation=http://brooklyn.apache.org/documentation/index.html
 
 [Service]
-ExecStart=/home/ubuntu/apache-brooklyn/bin/brooklyn launch --persist auto --persistenceDir /vagrant/brooklyn-persisted-state --catalogAdd /vagrant/files/vagrant-catalog.bom
-WorkingDirectory=/home/ubuntu/apache-brooklyn
+ExecStart=/home/vagrant/apache-brooklyn/bin/brooklyn launch --persist auto --persistenceDir /vagrant/brooklyn-persisted-state --catalogAdd /vagrant/files/vagrant-catalog.bom
+WorkingDirectory=/home/vagrant/apache-brooklyn
 Restart=on-abort
-User=ubuntu
-Group=ubuntu
+User=vagrant
+Group=vagrant
 
 [Install]
 WantedBy=multi-user.target

--- a/vagrant/src/main/vagrant/files/install_brooklyn.sh
+++ b/vagrant/src/main/vagrant/files/install_brooklyn.sh
@@ -48,11 +48,11 @@ fi
 if [ ! "${INSTALL_FROM_LOCAL_DIST}" == "true" ]; then
   if [ ! -z "${BROOKLYN_VERSION##*-SNAPSHOT}" ] ; then
     # url for official release versions
-    BROOKLYN_URL="https://www.apache.org/dyn/closer.lua?action=download&filename=brooklyn/apache-brooklyn-${BROOKLYN_VERSION}/apache-brooklyn-${BROOKLYN_VERSION}-bin.tar.gz"
+    BROOKLYN_URL="https://dist.apache.org/repos/dist/dev/brooklyn/apache-brooklyn-0.10.0-rc1/apache-brooklyn-0.10.0-rc1-bin.tar.gz"
     BROOKLYN_DIR="apache-brooklyn-${BROOKLYN_VERSION}-bin"
   else
     # url for community-managed snapshots
-    BROOKLYN_URL="https://repository.apache.org/service/local/artifact/maven/redirect?r=snapshots&g=org.apache.brooklyn&a=brooklyn-dist&v=${BROOKLYN_VERSION}&c=dist&e=tar.gz"
+    #BROOKLYN_URL="https://repository.apache.org/service/local/artifact/maven/redirect?r=snapshots&g=org.apache.brooklyn&a=brooklyn-dist&v=${BROOKLYN_VERSION}&c=dist&e=tar.gz"
     BROOKLYN_DIR="brooklyn-dist-${BROOKLYN_VERSION}"
   fi
 else
@@ -78,12 +78,12 @@ tar zxf ${TMP_ARCHIVE_NAME}
 echo "Creating Brooklyn dirs and symlinks"
 ln -s ${BROOKLYN_DIR} apache-brooklyn
 sudo mkdir -p /var/log/brooklyn
-sudo chown -R vagrant:vagrant /var/log/brooklyn
-mkdir -p /home/vagrant/.brooklyn
+sudo chown -R ubuntu:ubuntu /var/log/brooklyn
+mkdir -p /home/ubuntu/.brooklyn
 
 echo "Copying default vagrant Brooklyn properties file"
-cp /vagrant/files/brooklyn.properties /home/vagrant/.brooklyn/
-chmod 600 /home/vagrant/.brooklyn/brooklyn.properties
+cp /vagrant/files/brooklyn.properties /home/ubuntu/.brooklyn/
+chmod 600 /home/ubuntu/.brooklyn/brooklyn.properties
 
 echo "Installing JRE"
 sudo sh -c 'export DEBIAN_FRONTEND=noninteractive; apt-get install --yes openjdk-8-jre-headless'

--- a/vagrant/src/main/vagrant/files/install_brooklyn.sh
+++ b/vagrant/src/main/vagrant/files/install_brooklyn.sh
@@ -48,11 +48,11 @@ fi
 if [ ! "${INSTALL_FROM_LOCAL_DIST}" == "true" ]; then
   if [ ! -z "${BROOKLYN_VERSION##*-SNAPSHOT}" ] ; then
     # url for official release versions
-    BROOKLYN_URL="https://dist.apache.org/repos/dist/dev/brooklyn/apache-brooklyn-0.10.0-rc1/apache-brooklyn-0.10.0-rc1-bin.tar.gz"
+    BROOKLYN_URL="https://www.apache.org/dyn/closer.lua?action=download&filename=brooklyn/apache-brooklyn-${BROOKLYN_VERSION}/apache-brooklyn-${BROOKLYN_VERSION}-bin.tar.gz"
     BROOKLYN_DIR="apache-brooklyn-${BROOKLYN_VERSION}-bin"
   else
     # url for community-managed snapshots
-    #BROOKLYN_URL="https://repository.apache.org/service/local/artifact/maven/redirect?r=snapshots&g=org.apache.brooklyn&a=brooklyn-dist&v=${BROOKLYN_VERSION}&c=dist&e=tar.gz"
+    BROOKLYN_URL="https://repository.apache.org/service/local/artifact/maven/redirect?r=snapshots&g=org.apache.brooklyn&a=brooklyn-dist&v=${BROOKLYN_VERSION}&c=dist&e=tar.gz"
     BROOKLYN_DIR="brooklyn-dist-${BROOKLYN_VERSION}"
   fi
 else

--- a/vagrant/src/main/vagrant/files/install_brooklyn.sh
+++ b/vagrant/src/main/vagrant/files/install_brooklyn.sh
@@ -86,7 +86,7 @@ cp /vagrant/files/brooklyn.properties /home/vagrant/.brooklyn/
 chmod 600 /home/vagrant/.brooklyn/brooklyn.properties
 
 echo "Installing JRE"
-sudo sh -c 'yum install -y java-1.8.0-openjdk-headless'
+sudo sh -c 'yum -y install java-1.8.0-openjdk-headless'
 
 echo "Copying Brooklyn systemd service unit file"
 sudo cp /vagrant/files/brooklyn.service /etc/systemd/system/brooklyn.service

--- a/vagrant/src/main/vagrant/files/install_brooklyn.sh
+++ b/vagrant/src/main/vagrant/files/install_brooklyn.sh
@@ -78,15 +78,15 @@ tar zxf ${TMP_ARCHIVE_NAME}
 echo "Creating Brooklyn dirs and symlinks"
 ln -s ${BROOKLYN_DIR} apache-brooklyn
 sudo mkdir -p /var/log/brooklyn
-sudo chown -R ubuntu:ubuntu /var/log/brooklyn
-mkdir -p /home/ubuntu/.brooklyn
+sudo chown -R vagrant:vagrant /var/log/brooklyn
+mkdir -p /home/vagrant/.brooklyn
 
 echo "Copying default vagrant Brooklyn properties file"
-cp /vagrant/files/brooklyn.properties /home/ubuntu/.brooklyn/
-chmod 600 /home/ubuntu/.brooklyn/brooklyn.properties
+cp /vagrant/files/brooklyn.properties /home/vagrant/.brooklyn/
+chmod 600 /home/vagrant/.brooklyn/brooklyn.properties
 
 echo "Installing JRE"
-sudo sh -c 'export DEBIAN_FRONTEND=noninteractive; apt-get install --yes openjdk-8-jre-headless'
+sudo sh -c 'yum install -y java-1.8.0-openjdk-headless'
 
 echo "Copying Brooklyn systemd service unit file"
 sudo cp /vagrant/files/brooklyn.service /etc/systemd/system/brooklyn.service

--- a/vagrant/src/main/vagrant/servers.yaml
+++ b/vagrant/src/main/vagrant/servers.yaml
@@ -38,7 +38,7 @@ default_config:
     run_os_update: true
 servers:
   - name: brooklyn
-    box: ubuntu/xenial64
+    box: centos/7
     ram: 2048
     cpus: 4
     forwarded_ports:

--- a/vagrant/src/main/vagrant/servers.yaml
+++ b/vagrant/src/main/vagrant/servers.yaml
@@ -47,7 +47,7 @@ servers:
        autocorrect: true
     shell:
       env:
-        BROOKLYN_VERSION: "0.10.0"
+        BROOKLYN_VERSION: "0.11.0-SNAPSHOT"
         INSTALL_FROM_LOCAL_DIST: false
       cmd:
         - ssh-keygen -t rsa -N "" -f $HOME/.ssh/id_rsa

--- a/vagrant/src/main/vagrant/servers.yaml
+++ b/vagrant/src/main/vagrant/servers.yaml
@@ -47,7 +47,7 @@ servers:
        autocorrect: true
     shell:
       env:
-        BROOKLYN_VERSION: "0.11.0-SNAPSHOT"
+        BROOKLYN_VERSION: "0.10.0"
         INSTALL_FROM_LOCAL_DIST: false
       cmd:
         - ssh-keygen -t rsa -N "" -f $HOME/.ssh/id_rsa
@@ -60,19 +60,39 @@ servers:
     ram: 512
     cpus: 2
     ip: 10.10.10.101
+    shell:
+      env: {}
+      cmd:
+        - sudo sed -i 's/PasswordAuthentication no/PasswordAuthentication yes/g' /etc/ssh/sshd_config
+        - sudo service sshd restart
   - name: byon2
     box: centos/7
     ram: 512
     cpus: 2
     ip: 10.10.10.102
+    shell:
+      env: {}
+      cmd:
+        - sudo sed -i 's/PasswordAuthentication no/PasswordAuthentication yes/g' /etc/ssh/sshd_config
+        - sudo service sshd restart
   - name: byon3
     box: centos/7
     ram: 512
     cpus: 2
     ip: 10.10.10.103
+    shell:
+      env: {}
+      cmd:
+        - sudo sed -i 's/PasswordAuthentication no/PasswordAuthentication yes/g' /etc/ssh/sshd_config
+        - sudo service sshd restart
   - name: byon4
     box: centos/7
     ram: 512
     cpus: 2
     ip: 10.10.10.104
+    shell:
+      env: {}
+      cmd:
+        - sudo sed -i 's/PasswordAuthentication no/PasswordAuthentication yes/g' /etc/ssh/sshd_config
+        - sudo service sshd restart
 ...

--- a/vagrant/src/main/vagrant/servers.yaml
+++ b/vagrant/src/main/vagrant/servers.yaml
@@ -38,7 +38,7 @@ default_config:
     run_os_update: true
 servers:
   - name: brooklyn
-    box: ubuntu/wily64
+    box: ubuntu/xenial64
     ram: 2048
     cpus: 4
     forwarded_ports:
@@ -56,22 +56,22 @@ servers:
         - sudo systemctl start brooklyn
         - sudo systemctl enable brooklyn
   - name: byon1
-    box: ubuntu/wily64
+    box: centos/7
     ram: 512
     cpus: 2
     ip: 10.10.10.101
   - name: byon2
-    box: ubuntu/wily64
+    box: centos/7
     ram: 512
     cpus: 2
     ip: 10.10.10.102
   - name: byon3
-    box: ubuntu/wily64
+    box: centos/7
     ram: 512
     cpus: 2
     ip: 10.10.10.103
   - name: byon4
-    box: ubuntu/wily64
+    box: centos/7
     ram: 512
     cpus: 2
     ip: 10.10.10.104


### PR DESCRIPTION
Ubuntu wily is now EOL so move to Xenial LTS and Centos 7 which is better supported by blueprints. Note that to test this, you can use [this commit](https://github.com/apache/brooklyn-dist/pull/67/commits/08aba9135113220fa484cd8649056af789f90878) which includes a hard coded URL and version for Brooklyn.