### PR TITLE
Reorder `brooklyn-locations-jclouds` so that its installed before library features 

### DIFF
--- a/karaf/features/src/main/feature/feature.xml
+++ b/karaf/features/src/main/feature/feature.xml
@@ -59,11 +59,11 @@
         <feature prerequisite="true">brooklyn-standard-karaf</feature>
         <feature prerequisite="true">brooklyn-guava-optional-deps</feature>
         <feature>brooklyn-core</feature>
+        <feature>brooklyn-locations-jclouds</feature>
         <feature>brooklyn-rest-resources</feature>
         <feature>brooklyn-commands</feature>
         <feature>brooklyn-server-software-all</feature>
         <feature>brooklyn-library-all</feature>
-        <feature>brooklyn-locations-jclouds</feature>
     </feature>
 
     <feature name="brooklyn-jsgui-prereqs" version="${project.version}" description="Brooklyn REST JavaScript Web GUI">


### PR DESCRIPTION
Related to https://github.com/apache/brooklyn-server/pull/481