### PR TITLE
remove unnecessary versions in karaf pom

### DIFF
--- a/karaf/pom.xml
+++ b/karaf/pom.xml
@@ -38,17 +38,6 @@
     </parent>
 
     <properties>
-        <!-- TODO: duplicates in brooklyn-server/karaf/pom.xml -->
-        <karaf.version>4.0.4</karaf.version>
-        <!--
-            Fixes double User-Agent issue leading to split Nexus repo.
-            Caused by karaf-maven-plugin depending on wagon-http 2.8 having the bug.
-         -->
-        <karaf.plugin.version>4.0.6</karaf.plugin.version>
-        <logback.version>1.0.7</logback.version>
-        <org.osgi.core.version>6.0.0</org.osgi.core.version>
-        <geronimo-jta_1.1_spec.version>1.1.1</geronimo-jta_1.1_spec.version>
-
         <org.osgi.compendium.version>5.0.0</org.osgi.compendium.version>
         <lifecycle-mapping-plugin.version>1.0.0</lifecycle-mapping-plugin.version>
 


### PR DESCRIPTION
(the ones removed are declared in brooklyn-server/pom.xml)

i see this is also included in #48 but there are now conflicts and this partial improvement can be done now without waiting on that, i think -- @neykov ?