### PR TITLE
Make the default catalog location configurable

### DIFF
--- a/karaf/apache-brooklyn/src/main/resources/etc/org.apache.brooklyn.osgilauncher.cfg
+++ b/karaf/apache-brooklyn/src/main/resources/etc/org.apache.brooklyn.osgilauncher.cfg
@@ -27,6 +27,9 @@
 # Location of the global brooklyn.properties file
 #globalBrooklynPropertiesFile=~/.brooklyn/brooklyn.properties
 
+# Location of the default catalog.bom
+default.catalog.location=${karaf.etc}/default.catalog.bom
+
 # Location of the local brooklyn.properties file, normally specified at the cli. Overrides properties from the global set.
 #localBrooklynPropertiesFile=
 


### PR DESCRIPTION
default catalog location can now be configured using the below PID

`org.apache.brooklyn.osgilauncher/default.catalog.location`

default has been set as `${karaf.etc}/default.catalog.bom`