### PR TITLE
Add missing @Override annotations and other cleanup

### DIFF
--- a/karaf/itest/src/test/java/org/apache/brooklyn/AssemblyTest.java
+++ b/karaf/itest/src/test/java/org/apache/brooklyn/AssemblyTest.java
@@ -26,7 +26,6 @@ import javax.inject.Inject;
 
 import org.apache.karaf.features.BootFinished;
 import org.apache.karaf.features.FeaturesService;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.Configuration;

--- a/karaf/itest/src/test/java/org/apache/brooklyn/core/catalog/internal/CatalogBomScannerTest.java
+++ b/karaf/itest/src/test/java/org/apache/brooklyn/core/catalog/internal/CatalogBomScannerTest.java
@@ -48,9 +48,6 @@ import static org.apache.brooklyn.KarafTestUtils.defaultOptionsWith;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.editConfigurationFilePut;
-import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
-import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.logLevel;
 
 @RunWith(PaxExam.class)
 @ExamReactorStrategy(PerMethod.class)

--- a/karaf/itest/src/test/java/org/apache/brooklyn/security/CustomSecurityProviderTest.java
+++ b/karaf/itest/src/test/java/org/apache/brooklyn/security/CustomSecurityProviderTest.java
@@ -124,6 +124,7 @@ public class CustomSecurityProviderTest {
     private LoginContext doLogin(final String username, final String password) throws LoginException {
         assertRealmRegisteredEventually(WEBCONSOLE_REALM);
         LoginContext lc = new LoginContext(WEBCONSOLE_REALM, new CallbackHandler() {
+            @Override
             public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
                 for (int i = 0; i < callbacks.length; i++) {
                     Callback callback = callbacks[i];

--- a/karaf/itest/src/test/java/org/apache/brooklyn/security/StockSecurityProviderTest.java
+++ b/karaf/itest/src/test/java/org/apache/brooklyn/security/StockSecurityProviderTest.java
@@ -159,6 +159,7 @@ public class StockSecurityProviderTest {
     private LoginContext doLogin(final String username, final String password) throws LoginException {
         assertRealmRegisteredEventually(WEBCONSOLE_REALM);
         LoginContext lc = new LoginContext(WEBCONSOLE_REALM, new CallbackHandler() {
+            @Override
             public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
                 for (int i = 0; i < callbacks.length; i++) {
                     Callback callback = callbacks[i];


### PR DESCRIPTION
Triggered by a refactoring I had to do and missing a bunch of places that needed updating.

* add missing `@Override` annotations
* add missing `@Deprecated` annotations (usually just javadoc `@override` exists)
* remove unused imports
* remove unnecessary casts

Look at each commit individually.
Similar PRs created for the other brooklyn sub-projects.