### PR TITLE
Avoid sshd.core bundle rewiring on startup

### DIFF
--- a/karaf/features/src/main/feature/feature.xml
+++ b/karaf/features/src/main/feature/feature.xml
@@ -43,7 +43,7 @@
         <feature>package</feature>
         <feature>service</feature>
         <feature>system</feature>
-        <!-- load BouncyCastle early, to avoid "Refreshing bundles" later -->
+        <!-- load BouncyCastle early, to avoid refreshing of org.apache.sshd.core/0.14.0 later -->
         <bundle dependency="true">mvn:org.bouncycastle/bcprov-ext-jdk15on/${bouncycastle.version}</bundle>
         <bundle dependency="true">mvn:org.bouncycastle/bcpkix-jdk15on/${bouncycastle.version}</bundle>
     </feature>


### PR DESCRIPTION
This builds on Svet's https://github.com/apache/brooklyn-dist/pull/48 (which has now been merged).

It avoids the rewiring of the bundle org.apache.sshd.core, which would otherwise happen when bouncycastle bundles were later installed.

I've been testing it with https://github.com/apache/brooklyn-server/pull/547.