### PR TITLE
Load BouncyCastle bundles early on

### DIFF
--- a/downstream-parent/pom.xml
+++ b/downstream-parent/pom.xml
@@ -169,7 +169,7 @@
         <plugin>
           <groupId>org.apache.felix</groupId>
           <artifactId>maven-bundle-plugin</artifactId>
-          <version>2.3.4</version>
+          <version>3.2.0</version>
         </plugin>
         <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
         <plugin>

--- a/karaf/apache-brooklyn/src/main/resources/etc/system.properties
+++ b/karaf/apache-brooklyn/src/main/resources/etc/system.properties
@@ -131,12 +131,3 @@ karaf.secured.services = (&(osgi.command.scope=*)(osgi.command.function=*))
 # You can specify the location of the lock file using the
 # karaf.lock.dir=/path/to/the/directory/containing/the/lock
 #
-
-#
-# Explicitly prevent Karaf's sshd from registering BouncyCastle
-# to suppress misleading message in the log.
-#
-# TODO: We have BouncyCastle but it's an older version than the one org.apache.sshd
-# requires (1.49 vs 1.51). Once we update our dependency version we should revisit this.
-#
-org.apache.sshd.registerBouncyCastle = false

--- a/karaf/features/src/main/feature/feature.xml
+++ b/karaf/features/src/main/feature/feature.xml
@@ -43,6 +43,9 @@
         <feature>package</feature>
         <feature>service</feature>
         <feature>system</feature>
+        <!-- load BouncyCastle early, to avoid "Refreshing bundles" later -->
+        <bundle dependency="true">mvn:org.bouncycastle/bcprov-ext-jdk15on/${bouncycastle.version}</bundle>
+        <bundle dependency="true">mvn:org.bouncycastle/bcpkix-jdk15on/${bouncycastle.version}</bundle>
     </feature>
 
     <feature name="brooklyn-startup-features" version="${project.version}" description="Bundles to add to startup.properties">


### PR DESCRIPTION
Change OSGi feature to load BouncyCastle early, to avoid "Refreshing bundles" later