### PR TITLE
don't exclude apache http in karaf subprojects

### DIFF
--- a/downstream-parent/pom.xml
+++ b/downstream-parent/pom.xml
@@ -473,7 +473,6 @@
                   !io.cloudsoft.winrm4j.*,
                   !javax.inject.*,
                   !org.apache.felix.framework.*,
-                  !org.apache.http.*,
                   !org.jclouds.googlecomputeengine.*,
                   !org.osgi.jmx,
                   !org.python.*,


### PR DESCRIPTION
`org.apache.http.*` now works fine via `Import-Packages` so shouldn't be excluded, and downstream projects no longer need to do anything special if they use this package space