### PR TITLE
switch vagrant boxes to bento images

### DIFF
--- a/shared-packaging/src/test/yaml/Vagrantfile
+++ b/shared-packaging/src/test/yaml/Vagrantfile
@@ -41,7 +41,7 @@ Vagrant.configure(2) do |config|
     config.vm.network "private_network", ip: "172.28.128.4"
   end
   config.vm.define "yum-systemd" do |config|
-    config.vm.box = "centos/7"
+    config.vm.box = "bento/centos-7.3"
     config.vm.network "private_network", ip: "172.28.128.5"
   end
   config.vm.define "yum-upstart" do |config|

--- a/vagrant/src/main/vagrant/servers.yaml
+++ b/vagrant/src/main/vagrant/servers.yaml
@@ -38,7 +38,7 @@ default_config:
     run_os_update: true
 servers:
   - name: brooklyn
-    box: centos/7
+    box: bento/centos-7.3
     ram: 2048
     cpus: 4
     forwarded_ports:
@@ -56,7 +56,7 @@ servers:
         - sudo systemctl start brooklyn
         - sudo systemctl enable brooklyn
   - name: byon1
-    box: centos/7
+    box: bento/centos-7.3
     ram: 512
     cpus: 2
     ip: 10.10.10.101
@@ -66,7 +66,7 @@ servers:
         - sudo sed -i 's/PasswordAuthentication no/PasswordAuthentication yes/g' /etc/ssh/sshd_config
         - sudo service sshd restart
   - name: byon2
-    box: centos/7
+    box: bento/centos-7.3
     ram: 512
     cpus: 2
     ip: 10.10.10.102
@@ -76,7 +76,7 @@ servers:
         - sudo sed -i 's/PasswordAuthentication no/PasswordAuthentication yes/g' /etc/ssh/sshd_config
         - sudo service sshd restart
   - name: byon3
-    box: centos/7
+    box: bento/centos-7.3
     ram: 512
     cpus: 2
     ip: 10.10.10.103
@@ -86,7 +86,7 @@ servers:
         - sudo sed -i 's/PasswordAuthentication no/PasswordAuthentication yes/g' /etc/ssh/sshd_config
         - sudo service sshd restart
   - name: byon4
-    box: centos/7
+    box: bento/centos-7.3
     ram: 512
     cpus: 2
     ip: 10.10.10.104


### PR DESCRIPTION
Prior to this PR running the vagrant getting started environment would fall back to using rsync for making the `/vagrant` share available in the guest OS due to the `centos/7` box not including virtualbox guest additions (resulting in the absense of the vboxfs drivers). This would complicate using the vagrant env on Windows where rsync is not available by default. The `centos/X` boxes do not following current best practices for virtualbox providers.

This commit switches to the community managed bentos centos-7.3 box which follows best practices and includes the vbox guest additions. See - https://github.com/chef/bento