### PR TITLE
Fix namespace on feature.xml

### DIFF
--- a/karaf/features/src/main/feature/feature.xml
+++ b/karaf/features/src/main/feature/feature.xml
@@ -16,7 +16,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<features xmlns="http://karaf.apache.org/xmlns/features/v1.2.0"
+<features xmlns="http://karaf.apache.org/xmlns/features/v1.4.0"
           name="org.apache.brooklyn-${project.version}"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:noNamespaceSchemaLocation="http://karaf.apache.org/xmlns/features/v1.2.0">


### PR DESCRIPTION
Updates namespace on the file to http://karaf.apache.org/xmlns/features/v1.4.0
which is required for 'prerequisite="true"' on feature declarations.