### PR TITLE
Bring namespace on feature files to Karaf features 1.4.0

### DIFF
--- a/karaf/features/src/main/feature/feature.xml
+++ b/karaf/features/src/main/feature/feature.xml
@@ -19,7 +19,7 @@
 <features xmlns="http://karaf.apache.org/xmlns/features/v1.4.0"
           name="org.apache.brooklyn-${project.version}"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="http://karaf.apache.org/xmlns/features/v1.2.0">
+          xsi:noNamespaceSchemaLocation="http://karaf.apache.org/xmlns/features/v1.4.0">
 
     <feature name="brooklyn-standard-karaf" version="${project.version}" description="Karaf standard feature with RMI excluded">
         <feature>wrap</feature>


### PR DESCRIPTION
Updates namespace on the file to http://karaf.apache.org/xmlns/features/v1.4.0
which is required for 'prerequisite="true"' on feature declarations.