### PR TITLE
Add the container service dependencies to the main distribution

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -52,6 +52,11 @@
             <artifactId>brooklyn-locations-jclouds</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.brooklyn</groupId>
+            <artifactId>brooklyn-locations-container</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>org.apache.brooklyn</groupId>
@@ -116,7 +121,6 @@
             <artifactId>brooklyn-test-framework</artifactId>
             <version>${project.version}</version>
         </dependency>
-
 
         <!-- bring in all jclouds-supported cloud providers -->
         <dependency>


### PR DESCRIPTION
Updates the `brooklyn-all` POM to include the new `brooklyn-container-service` code added by https://github.com/apache/brooklyn-server/pull/732