### PR TITLE
Don't avoid importing jclouds google compute engine.

### DIFF
--- a/downstream-parent/pom.xml
+++ b/downstream-parent/pom.xml
@@ -473,7 +473,6 @@
                   !io.cloudsoft.winrm4j.*,
                   !javax.inject.*,
                   !org.apache.felix.framework.*,
-                  !org.jclouds.googlecomputeengine.*,
                   !org.osgi.jmx,
                   !org.python.*,
                   !org.reflections.*,


### PR DESCRIPTION
This is a bundle by now.

This change is required in a downstream project to be able to access GCE correctly from within Karaf.