### PR TITLE
Modular catalog.bom

### DIFF
--- a/deb-packaging/pom.xml
+++ b/deb-packaging/pom.xml
@@ -117,11 +117,12 @@
                                     </mapper>
                                 </data>
                                 <data>
-                                    <src>${project.build.directory}/deps/apache-brooklyn-${project.version}/catalog</src>
-                                    <type>directory</type>
+                                    <type>template</type>
+                                    <paths>
+                                        <path>/opt/brooklyn-${project.version}/catalog</path>
+                                    </paths>
                                     <mapper>
                                         <type>perm</type>
-                                        <prefix>/opt/brooklyn-${project.version}/catalog</prefix>
                                         <user>brooklyn</user>
                                         <group>brooklyn</group>
                                         <filemode>${brooklyn.file.permission.default}</filemode>

--- a/karaf/config/pom.xml
+++ b/karaf/config/pom.xml
@@ -45,6 +45,27 @@
                                     <type>cfg</type>
                                     <classifier>osgilauncher</classifier>
                                 </artifact>
+                                <artifact>
+                                    <file>
+                                        ${project.basedir}/src/main/resources/catalog/catalog.bom
+                                    </file>
+                                    <type>bom</type>
+                                    <classifier>catalog</classifier>
+                                </artifact>
+                                <artifact>
+                                    <file>
+                                        ${project.basedir}/src/main/resources/catalog/catalog-core.bom
+                                    </file>
+                                    <type>bom</type>
+                                    <classifier>catalog-core</classifier>
+                                </artifact>
+                                <artifact>
+                                    <file>
+                                        ${project.basedir}/src/main/resources/catalog/catalog-templates.bom
+                                    </file>
+                                    <type>bom</type>
+                                    <classifier>catalog-templates</classifier>
+                                </artifact>
                             </artifacts>
                         </configuration>
                     </execution>

--- a/karaf/config/src/main/resources/catalog/catalog-core.bom
+++ b/karaf/config/src/main/resources/catalog/catalog-core.bom
@@ -1,0 +1,23 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+brooklyn.catalog:
+  version: "0.13.0-SNAPSHOT" # BROOKLYN_VERSION
+
+  items:
+  - classpath://org.apache.brooklyn.karaf-init:0.13.0-SNAPSHOT:catalog.bom # BROOKLYN_VERSION
+  - classpath://org.apache.brooklyn.library-catalog:0.13.0-SNAPSHOT:catalog.bom # BROOKLYN_VERSION

--- a/karaf/config/src/main/resources/catalog/catalog-core.bom
+++ b/karaf/config/src/main/resources/catalog/catalog-core.bom
@@ -18,6 +18,6 @@
 brooklyn.catalog:
   version: "0.13.0-SNAPSHOT" # BROOKLYN_VERSION
 
-  items:
-  - classpath://org.apache.brooklyn.karaf-init:0.13.0-SNAPSHOT:catalog.bom # BROOKLYN_VERSION
-  - classpath://org.apache.brooklyn.library-catalog:0.13.0-SNAPSHOT:catalog.bom # BROOKLYN_VERSION
+  brooklyn.libraries:
+  - mvn:org.apache.brooklyn/brooklyn-karaf-init/0.13.0-SNAPSHOT # BROOKLYN_VERSION
+  - mvn:org.apache.brooklyn/brooklyn-library-catalog/0.13.0-SNAPSHOT # BROOKLYN_VERSION

--- a/karaf/config/src/main/resources/catalog/catalog-templates.bom
+++ b/karaf/config/src/main/resources/catalog/catalog-templates.bom
@@ -1,13 +1,24 @@
-
-# this catalog bom is an illustration supplying a few useful sample items
-# and templates to get started using Brooklyn
-
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
 brooklyn.catalog:
   version: "0.13.0-SNAPSHOT" # BROOKLYN_VERSION
-  include: classpath://library-catalog-classes.bom
 
   items:
-
   - id: server
     itemType: entity
     description: |

--- a/karaf/config/src/main/resources/catalog/catalog.bom
+++ b/karaf/config/src/main/resources/catalog/catalog.bom
@@ -1,0 +1,23 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+brooklyn.catalog:
+  version: "0.13.0-SNAPSHOT" # BROOKLYN_VERSION
+
+  items:
+  - 'file:catalog/catalog-core.bom'
+  - 'file:catalog/catalog-templates.bom'

--- a/karaf/features/src/main/feature/feature.xml
+++ b/karaf/features/src/main/feature/feature.xml
@@ -67,8 +67,21 @@
         </configfile>
     </feature>
 
+    <feature name="brooklyn-catalog" version="${project.version}">
+        <configfile finalname="${karaf.home}/catalog/catalog.bom" override="false">
+            mvn:${project.groupId}/brooklyn-dist-config/${project.version}/bom/catalog
+        </configfile>
+        <configfile finalname="${karaf.home}/catalog/catalog-core.bom" override="false">
+            mvn:${project.groupId}/brooklyn-dist-config/${project.version}/bom/catalog-core
+        </configfile>
+        <configfile finalname="${karaf.home}/catalog/catalog-templates.bom" override="false">
+            mvn:${project.groupId}/brooklyn-dist-config/${project.version}/bom/catalog-templates
+        </configfile>
+    </feature>
+
     <feature name="brooklyn-headless" version="${project.version}" description="All Brooklyn bundles witht the exception of the launcher">
         <feature prerequisite="true">brooklyn-config</feature>
+        <feature prerequisite="true">brooklyn-catalog</feature>
         <feature prerequisite="true">brooklyn-standard-karaf</feature>
         <feature prerequisite="true">brooklyn-guava-optional-deps</feature>
         <feature>brooklyn-core</feature>

--- a/rpm-packaging/pom.xml
+++ b/rpm-packaging/pom.xml
@@ -132,11 +132,6 @@
                         </mapping>
                         <mapping>
                             <directory>/opt/brooklyn-${project.version}/catalog</directory>
-                            <sources>
-                                <source>
-                                    <location>${project.build.directory}/deps/apache-brooklyn-${project.version}/catalog</location>
-                                </source>
-                            </sources>
                         </mapping>
                         <mapping>
                             <directory>/opt/brooklyn-${project.version}/data</directory>


### PR DESCRIPTION
This reuses each bundle's `catalog.bom` file to build global `catalog.bom`. 

It avoids the duplication of bom files and keep all the metadata (title, description, iconUrl, etc) under the same module that contains the actual Java entity.

It also creates a `brooklyn-catalog` feature for Karaf for downstream project to reuse it, if required.

Those changes spans across `brooklyn-server`, `brooklyn-library` and `brooklyn-dist`. 

This requires (and should be tested with):
- https://github.com/apache/brooklyn-server/pull/834
- https://github.com/apache/brooklyn-library/pull/130 