### PR TITLE
Fix release scripts

### DIFF
--- a/release/Vagrantfile
+++ b/release/Vagrantfile
@@ -60,8 +60,10 @@ Vagrant.configure(2) do |config|
 
   config.vm.provision "file", source: "~/.gitconfig", destination: ".gitconfig"
   config.vm.provision "file", source: "~/.gnupg/gpg.conf", destination: ".gnupg/gpg.conf"
-  config.vm.provision "file", source: "~/.gnupg/pubring.gpg", destination: ".gnupg/pubring.gpg"
-  config.vm.provision "file", source: "~/.gnupg/secring.gpg", destination: ".gnupg/secring.gpg"
+
+  # Uncomment these lines if you would like to include your local gnupg keys
+  #config.vm.provision "file", source: "~/.gnupg/pubring.gpg", destination: ".gnupg/pubring.gpg"
+  #config.vm.provision "file", source: "~/.gnupg/secring.gpg", destination: ".gnupg/secring.gpg"
   config.vm.provision "file", source: "gpg-agent.conf", destination: ".gnupg/gpg-agent.conf"
   config.vm.provision "file", source: "settings.xml", destination: ".m2/settings.xml"
 
@@ -76,7 +78,7 @@ Vagrant.configure(2) do |config|
     apt-get install -y default-jdk git subversion xmlstarlet zip unzip language-pack-en \
                        vim-nox gnupg2 gnupg-agent pinentry-curses golang rpm mmv haveged
     mkdir -p /opt
-    MAVEN_VERSION=3.3.39
+    MAVEN_VERSION=3.3.3
     curl http://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz | tar xz -C /opt
     ln -s /opt/apache-maven-${MAVEN_VERSION}/bin/mvn /usr/local/bin
     mkdir -p /work

--- a/release/make-release-artifacts.sh
+++ b/release/make-release-artifacts.sh
@@ -226,14 +226,20 @@ set +x
 echo "Make CLI artifacts"
 set -x
 
+# copy in each of the br tools
+mkdir ${bin_staging_dir}/${release_name}-client-cli-linux
+mkdir ${bin_staging_dir}/${release_name}-client-cli-windows
+mkdir ${bin_staging_dir}/${release_name}-client-cli-macosx
+cp ${src_staging_dir}/brooklyn-client/cli/target/bin/linux.386/br ${bin_staging_dir}/${release_name}-client-cli-linux
+cp ${src_staging_dir}/brooklyn-client/cli/target/bin/windows.386/br.exe ${bin_staging_dir}/${release_name}-client-cli-windows
+cp ${src_staging_dir}/brooklyn-client/cli/target/bin/darwin.amd64/br ${bin_staging_dir}/${release_name}-client-cli-macosx
+
+# copy in the LICENSE, README and NOTICE
 for p in linux windows macosx; do
-    mkdir ${bin_staging_dir}/${release_name}-client-cli-${p}
-    rsync -a ${bin_staging_dir}/${release_name}-bin/bin/brooklyn-client-cli/ ${bin_staging_dir}/${release_name}-client-cli-${p} --exclude '*.386' --exclude '*.amd64'
-done
-cp ${bin_staging_dir}/${release_name}-bin/bin/brooklyn-client-cli/linux.386/br ${bin_staging_dir}/${release_name}-client-cli-linux
-cp ${bin_staging_dir}/${release_name}-bin/bin/brooklyn-client-cli/windows.386/br.exe ${bin_staging_dir}/${release_name}-client-cli-windows
-cp ${bin_staging_dir}/${release_name}-bin/bin/brooklyn-client-cli/darwin.amd64/br ${bin_staging_dir}/${release_name}-client-cli-macosx
-for p in linux windows macosx; do
+    cp ${src_staging_dir}/brooklyn-client/cli/release/files/README ${bin_staging_dir}/${release_name}-client-cli-${p}
+    cp ${src_staging_dir}/LICENSE ${bin_staging_dir}/${release_name}-client-cli-${p}
+    cp ${src_staging_dir}/NOTICE ${bin_staging_dir}/${release_name}-client-cli-${p}
+
     ( cd ${bin_staging_dir} && tar czf ${artifact_dir}/${artifact_name}-client-cli-${p}.tar.gz ${release_name}-client-cli-${p} )
     ( cd ${bin_staging_dir} && zip -qr ${artifact_dir}/${artifact_name}-client-cli-${p}.zip ${release_name}-client-cli-${p} )
 done
@@ -254,7 +260,12 @@ mv ${bin_staging_dir}/brooklyn-vagrant-${current_version} ${bin_staging_dir}/${r
 ###############################################################################
 # RPM artifacts
 
-cp ${src_staging_dir}/brooklyn-dist/rpm-packaging/target/rpm/apache-brooklyn/RPMS/noarch/apache-brooklyn-${current_version}-1.noarch.rpm ${artifact_dir}/${artifact_name}-1.noarch.rpm
+cp ${src_staging_dir}/brooklyn-dist/rpm-packaging/target/rpm/apache-brooklyn-noarch/RPMS/noarch/apache-brooklyn-${current_version}-1.noarch.rpm ${artifact_dir}/${artifact_name}-1.noarch.rpm
+
+###############################################################################
+# deb artifacts
+
+cp ${src_staging_dir}/brooklyn-dist/deb-packaging/target/apache-brooklyn-${current_version}-all.deb ${artifact_dir}/${artifact_name}.deb
 
 ###############################################################################
 # Signatures and checksums
@@ -264,7 +275,7 @@ cp ${src_staging_dir}/brooklyn-dist/rpm-packaging/target/rpm/apache-brooklyn/RPM
 which sha256sum >/dev/null || alias sha256sum='shasum -a 256' && shopt -s expand_aliases
 
 ( cd ${artifact_dir} &&
-    for a in *.tar.gz *.zip *.rpm; do
+    for a in *.tar.gz *.zip *.rpm *.deb; do
         md5sum -b ${a} > ${a}.md5
         sha1sum -b ${a} > ${a}.sha1
         sha256sum -b ${a} > ${a}.sha256


### PR DESCRIPTION
This makes the following changes to the release scripts:

* Fixes a typo in the maven version which is installed
* Doesn't copy over the local gpg keyring to the vagrant box

This is because it just uses the first one and if there are multiple keys on it, the wrong one will probably be used. Just manually copy on the keys (I'll amend the docs to document this).

* Updates the CLI artefacts with new structure
* Fixes the path to the built RPM
* Adds the deb