### PR TITLE
Fix vagrant installation folder when downloading dist version

### DIFF
--- a/vagrant/src/main/vagrant/files/install_brooklyn.sh
+++ b/vagrant/src/main/vagrant/files/install_brooklyn.sh
@@ -49,7 +49,7 @@ if [ ! "${INSTALL_FROM_LOCAL_DIST}" == "true" ]; then
   if [ ! -z "${BROOKLYN_VERSION##*-SNAPSHOT}" ] ; then
     # url for official release versions
     BROOKLYN_URL="https://www.apache.org/dyn/closer.lua?action=download&filename=brooklyn/apache-brooklyn-${BROOKLYN_VERSION}/apache-brooklyn-${BROOKLYN_VERSION}-bin.tar.gz"
-    BROOKLYN_DIR="apache-brooklyn-${BROOKLYN_VERSION}"
+    BROOKLYN_DIR="apache-brooklyn-${BROOKLYN_VERSION}-bin"
   else
     # url for community-managed snapshots
     BROOKLYN_URL="https://repository.apache.org/service/local/artifact/maven/redirect?r=snapshots&g=org.apache.brooklyn&a=apache-brooklyn&v=${BROOKLYN_VERSION}&e=tar.gz"


### PR DESCRIPTION
The name of the tar.gz archive is different for the dist version (i.e. `apache-brooklyn-<version>-bin`) and therefore, the name of the extracted folder needs to match that.

Based on the mailing list discussion: https://lists.apache.org/thread.html/104010308cf525da847894c4ec543a6f4ab20a6e0bf9212873422cbd@%3Cdev.brooklyn.apache.org%3E