### PR TITLE
brooklyn-all has a dependency on brooklyn-catalog-aliases

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -103,6 +103,11 @@
             <artifactId>brooklyn-software-network</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.brooklyn</groupId>
+            <artifactId>brooklyn-catalog-aliases</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>org.apache.brooklyn</groupId>


### PR DESCRIPTION
Without the dependency the build does not include the entity images for clusters and servers.