### PR TITLE
[BROOKLYN-579] Add DNS TTL configuration via envvar

### DIFF
--- a/karaf/apache-brooklyn/src/main/resources/bin/setenv
+++ b/karaf/apache-brooklyn/src/main/resources/bin/setenv
@@ -90,6 +90,9 @@ export EXTRA_JAVA_OPTS="-Dbrooklyn.location.localhost.address=127.0.0.1 ${EXTRA_
 export EXTRA_JAVA_OPTS="-XX:SoftRefLRUPolicyMSPerMB=1 ${EXTRA_JAVA_OPTS}"
 
 # Set the DNS TTL for the JVM
+# By default, java does not refresh DNS records, ever. This is due to the default value of networkaddress.cache.ttl set to -1, i.e. cache forever.
+# However, networkaddress.cache.ttl is not a system property, but a security property. It cannot be updated through from the JVM.
+# But, using the old system property sun.net.inetaddr.ttl has the desirable effect (see: https://stackoverflow.com/a/17219327)
 export EXTRA_JAVA_OPTS="-Dsun.net.inetaddr.ttl=${DNS_TTL} ${EXTRA_JAVA_OPTS}"
 
 # Set the TLS protocol versions

--- a/karaf/apache-brooklyn/src/main/resources/bin/setenv
+++ b/karaf/apache-brooklyn/src/main/resources/bin/setenv
@@ -23,6 +23,10 @@ fi
 if [ -z "${JAVA_MAX_PERM_MEM}" ] ; then
     export JAVA_MAX_PERM_MEM="256m"
 fi
+# use the default DNS TTL, if not specified
+if [ -z "${DNS_TTL}" ] ; then
+    export DNS_TTL="60"
+fi
 
 # OS specific support (must be 'true' or 'false').
     cygwin=false;
@@ -84,6 +88,9 @@ export EXTRA_JAVA_OPTS="-Dbrooklyn.location.localhost.address=127.0.0.1 ${EXTRA_
 
 # Increase garbage collection, see https://issues.apache.org/jira/browse/BROOKLYN-375
 export EXTRA_JAVA_OPTS="-XX:SoftRefLRUPolicyMSPerMB=1 ${EXTRA_JAVA_OPTS}"
+
+# Set the DNS TTL for the JVM
+export EXTRA_JAVA_OPTS="-Dsun.net.inetaddr.ttl=${DNS_TTL} ${EXTRA_JAVA_OPTS}"
 
 # Set the TLS protocol versions
 export EXTRA_JAVA_OPTS="-Dhttps.protocols=TLSv1.1,TLSv1.2 ${EXTRA_JAVA_OPTS}"


### PR DESCRIPTION
Before, java was not refreshing the DNS records, ever. This is due to the default `networkaddress.cache.ttl` set to `-1`, i.e. cache forever.

This PR updates the system property `sun.net.inetaddr.ttl` to `60` by default. It uses `sun.net.inetaddr.ttl` because `networkaddress.cache.ttl` **is not** a system property. But this has the desirable effect (see: https://stackoverflow.com/a/17219327)

