### PR TITLE
Update Brooklyn codebase to build the newly donated UI

### DIFF
--- a/karaf/features/pom.xml
+++ b/karaf/features/pom.xml
@@ -33,6 +33,17 @@
     <description>Defines Karaf features for Karaf runtime</description>
     <packaging>feature</packaging>
 
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.brooklyn.ui</groupId>
+            <artifactId>brooklyn-ui-features</artifactId>
+            <version>${project.version}</version>
+            <classifier>features</classifier>
+            <type>xml</type>
+            <scope>runtime</scope>
+        </dependency>
+    </dependencies>
+
     <build>
         <plugins>
             <plugin>

--- a/karaf/features/src/main/feature/feature.xml
+++ b/karaf/features/src/main/feature/feature.xml
@@ -21,6 +21,8 @@
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:noNamespaceSchemaLocation="http://karaf.apache.org/xmlns/features/v1.4.0">
 
+    <repository>mvn:${project.groupId}.ui/brooklyn-ui-features/${project.version}/xml/features</repository>
+
     <feature name="brooklyn-standard-karaf" version="${project.version}" description="Karaf standard feature with RMI excluded">
         <feature>wrap</feature>
         <feature>aries-blueprint</feature>
@@ -100,7 +102,7 @@
 
     <feature name="brooklyn-jsgui" version="${project.version}" description="Brooklyn REST JavaScript Web GUI">
         <feature>brooklyn-jsgui-prereqs</feature>
-        <bundle>mvn:org.apache.brooklyn/brooklyn-jsgui/${project.version}/war</bundle>
+        <feature>brooklyn-ui</feature>
     </feature>
 
     <feature name="brooklyn-boot" version="${project.version}" description="Bundles to start on boot">


### PR DESCRIPTION
See discussion about the donated UI: https://lists.apache.org/thread.html/20d82876f7e84244c2c4d3464a1531a10af50ca3d20e9e1de97a5faf@%3Cdev.brooklyn.apache.org%3E

This replaces the old UI by the new one.

Note that it requires:
- https://github.com/apache/brooklyn-server/pull/974
- https://github.com/apache/brooklyn-library/pull/156
- https://github.com/apache/brooklyn-ui/pull/54