### PR TITLE
Fix for SUREFIRE-1588

### DIFF
--- a/karaf/itest/pom.xml
+++ b/karaf/itest/pom.xml
@@ -252,6 +252,7 @@
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <useSystemClassLoader>false</useSystemClassLoader>
                     <groups>${includedTestGroups}</groups>
                     <excludedGroups>${excludedTestGroups}</excludedGroups>
                     <systemPropertyVariables>


### PR DESCRIPTION
Latest version of Java 1.8.0_191 enforces that Manifest classpath entries be relative.

https://issues.apache.org/jira/browse/SUREFIRE-1588