### PR TITLE
Update docker instructions to mount the docker socket

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ docker build -t brooklyn:dist .
 Then run the build:
 
 ```bash
-docker run -i --rm --name brooklyn-dist -v ${HOME}/.m2:/root/.m2 -v ${PWD}:/usr/build -w /usr/build brooklyn:dist mvn clean install
+docker run -i --rm --name brooklyn-dist -v /var/run/docker.sock:/var/run/docker.sock -v ${HOME}/.m2:/root/.m2 -v ${PWD}:/usr/build -w /usr/build brooklyn:dist mvn clean install
 ```
 
 ### Using maven


### PR DESCRIPTION
This is because #118 now build docker, therefore the container needs to be able to access the docker engine on the host