### PR TITLE
Update dockerfile-maven-plugin to 1.4.3 to fix build problem

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -126,7 +126,7 @@
             <plugin>
                 <groupId>com.spotify</groupId>
                 <artifactId>dockerfile-maven-plugin</artifactId>
-                <version>1.4.0</version>
+                <version>1.4.3</version>
                 <executions>
                     <execution>
                         <id>default</id>


### PR DESCRIPTION
Building on OSX I get

```
[ERROR] Failed to execute goal com.spotify:dockerfile-maven-plugin:1.4.0:build (default) on project brooklyn-dist: Could not build image: com.spotify.docker.client.shaded.com.fasterxml.jackson.databind.exc.MismatchedInputException: Cannot construct instance of `com.spotify.docker.client.messages.RegistryAuth` (although at least one Creator exists): no String-argument constructor/factory method to deserialize from String value ('osxkeychain')
[ERROR]  at [Source: UNKNOWN; line: -1, column: -1] (through reference chain: java.util.LinkedHashMap["credSstore"])
```

Updating the plugin to 1.4.3 per the comment below fixed this issue for
me.

https://github.com/dlcs/elucidate-server/issues/89#issuecomment-411219914