### PR TITLE
Avoid build depending on Docker by default

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -123,26 +123,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>com.spotify</groupId>
-                <artifactId>dockerfile-maven-plugin</artifactId>
-                <version>1.4.3</version>
-                <executions>
-                    <execution>
-                        <id>default</id>
-                        <goals>
-                            <goal>build</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <repository>apache/brooklyn</repository>
-                    <tag>${project.version}</tag>
-                    <buildArgs>
-                        <DIST_TAR_GZ>target/${project.build.finalName}-dist.tar.gz</DIST_TAR_GZ>
-                    </buildArgs>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 

--- a/docker-image/Dockerfile
+++ b/docker-image/Dockerfile
@@ -27,7 +27,7 @@ ENV EXTRA_JAVA_OPTS="-XX:SoftRefLRUPolicyMSPerMB=1 -Djava.security.egd=file:/dev
 
 RUN apk --no-cache add bash ; \
     mkdir brooklyn ; \
-    tar xvzf brooklyn.tar.gz -C /brooklyn --strip-components 1 ;
+    tar xzf brooklyn.tar.gz -C /brooklyn --strip-components 1 ;
 
-ENTRYPOINT ["/brooklyn/bin/brooklyn"]
-CMD ["launch"]
+ENTRYPOINT ["/brooklyn/bin/karaf"]
+CMD ["server"]

--- a/docker-image/README.md
+++ b/docker-image/README.md
@@ -1,0 +1,19 @@
+
+### Brooklyn Karaf Distribution Docker Image
+
+The instructions in this directory will build a Docker image of the `apache-brooklyn` Karaf distribution. 
+This is an optional step in the build of Apache Brooklyn, enabled as a profile:
+
+```bash
+mvn clean install -Pdocker 
+```
+
+Docker should be installed and running when doing such a build.
+
+The image can then be run as usual with Docker. For example create a folder `my-brooklyn-config` which 
+contains an `etc` directory containing your configuration for Brooklyn. Then Brooklyn can be run as:
+ 
+
+```bash
+docker run --name brooklyn -d -p8081:8081 -p8443:8443 -v ${HOME}/my-brooklyn-config/etc:/brooklyn/etc apache/brooklyn:1.0.0-SNAPSHOT
+```

--- a/docker-image/pom.xml
+++ b/docker-image/pom.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>karaf-docker-image</artifactId>
+  <packaging>pom</packaging>
+  <name>Brooklyn Karaf Distribution Docker Image</name>
+
+  <parent>
+      <groupId>org.apache.brooklyn</groupId>
+      <artifactId>brooklyn-dist-root</artifactId>
+      <version>1.0.0-SNAPSHOT</version>  <!-- BROOKLYN_VERSION -->
+      <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.brooklyn</groupId>
+      <artifactId>apache-brooklyn</artifactId>
+      <version>${project.version}</version>
+      <type>tar.gz</type>
+    </dependency>
+  </dependencies>
+
+  <profiles>
+    <profile>
+      <id>docker</id>
+      <activation>
+        <property>
+          <name>docker</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>copy-distro</id>
+                <phase>prepare-package</phase>
+                <goals>
+                  <goal>copy</goal>
+                </goals>
+                <configuration>
+                  <artifactItems>
+                    <artifactItem>
+                      <groupId>org.apache.brooklyn</groupId>
+                      <artifactId>apache-brooklyn</artifactId>
+                      <type>tar.gz</type>
+                      <outputDirectory>${project.build.directory}</outputDirectory>
+                      <destFileName>apache-brooklyn-${project.version}.tar.gz</destFileName>
+                    </artifactItem>
+                  </artifactItems>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>com.spotify</groupId>
+            <artifactId>dockerfile-maven-plugin</artifactId>
+            <version>1.4.3</version>
+            <executions>
+              <execution>
+                <id>default</id>
+                <goals>
+                  <goal>build</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <repository>apache/brooklyn</repository>
+              <tag>${project.version}</tag>
+              <buildArgs>
+                <DIST_TAR_GZ>target/apache-brooklyn-${project.version}.tar.gz</DIST_TAR_GZ>
+              </buildArgs>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
+</project>
+

--- a/pom.xml
+++ b/pom.xml
@@ -123,6 +123,7 @@
         <module>vagrant</module>
         <module>archetypes/quickstart</module>
         <module>shared-packaging</module>
+        <module>docker-image</module>
     </modules>
 
     <build>


### PR DESCRIPTION
To avoid the build failing if Docker is not installed and running,
put the docker image build into a profile, so build with

mvn clean install -Pdocker

This also moves the Dockerfile from `brooklyn-dist/dist` into karaf/apache-brooklyn
so it generates the image from the karaf distro.

We should remove `brooklyn-dist/dist` as well but that can be another PR.

See discussion on https://lists.apache.org/thread.html/f296ff5ed96002f165bdef95d0aac083261ff44c78c24c0a804fe4d9@%3Cdev.brooklyn.apache.org%3E