### PR TITLE
Make the build of rpm, deb and docker optional by default

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -128,10 +128,10 @@
 
     <profiles>
         <profile>
-            <id>go-client</id>
+            <id>client</id>
             <activation>
                 <property>
-                    <name>!no-go-client</name>
+                    <name>client</name>
                 </property>
             </activation>
             <build>

--- a/docker-image/pom.xml
+++ b/docker-image/pom.xml
@@ -24,7 +24,7 @@
 
   <artifactId>karaf-docker-image</artifactId>
   <packaging>pom</packaging>
-  <name>Brooklyn Karaf Distribution Docker Image</name>
+  <name>Brooklyn Docker Image</name>
 
   <parent>
       <groupId>org.apache.brooklyn</groupId>
@@ -42,63 +42,53 @@
     </dependency>
   </dependencies>
 
-  <profiles>
-    <profile>
-      <id>docker</id>
-      <activation>
-        <property>
-          <name>docker</name>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-dependency-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>copy-distro</id>
-                <phase>prepare-package</phase>
-                <goals>
-                  <goal>copy</goal>
-                </goals>
-                <configuration>
-                  <artifactItems>
-                    <artifactItem>
-                      <groupId>org.apache.brooklyn</groupId>
-                      <artifactId>apache-brooklyn</artifactId>
-                      <type>tar.gz</type>
-                      <outputDirectory>${project.build.directory}</outputDirectory>
-                      <destFileName>apache-brooklyn-${project.version}.tar.gz</destFileName>
-                    </artifactItem>
-                  </artifactItems>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>com.spotify</groupId>
-            <artifactId>dockerfile-maven-plugin</artifactId>
-            <version>${dockerfile-maven-plugin.version}</version>
-            <executions>
-              <execution>
-                <id>default</id>
-                <goals>
-                  <goal>build</goal>
-                </goals>
-              </execution>
-            </executions>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>copy-distro</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>copy</goal>
+            </goals>
             <configuration>
-              <repository>apache/brooklyn</repository>
-              <tag>${project.version}</tag>
-              <buildArgs>
-                <DIST_TAR_GZ>target/apache-brooklyn-${project.version}.tar.gz</DIST_TAR_GZ>
-              </buildArgs>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>org.apache.brooklyn</groupId>
+                  <artifactId>apache-brooklyn</artifactId>
+                  <type>tar.gz</type>
+                  <outputDirectory>${project.build.directory}</outputDirectory>
+                  <destFileName>apache-brooklyn-${project.version}.tar.gz</destFileName>
+                </artifactItem>
+              </artifactItems>
             </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>com.spotify</groupId>
+        <artifactId>dockerfile-maven-plugin</artifactId>
+        <version>${dockerfile-maven-plugin.version}</version>
+        <executions>
+          <execution>
+            <id>default</id>
+            <goals>
+              <goal>build</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <repository>apache/brooklyn</repository>
+          <tag>${project.version}</tag>
+          <buildArgs>
+            <DIST_TAR_GZ>target/apache-brooklyn-${project.version}.tar.gz</DIST_TAR_GZ>
+          </buildArgs>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 
 </project>
 

--- a/pom.xml
+++ b/pom.xml
@@ -89,11 +89,11 @@
 
     <profiles>
         <profile>
-            <!-- skip the RPM build by setting -Dno-rpm - useful if RPM tool is not available -->
-            <id>rpm-module</id>
+            <!-- Include the RPM build by setting -Drpm -->
+            <id>rpm</id>
             <activation>
                 <property>
-                    <name>!no-rpm</name>
+                    <name>rpm</name>
                 </property>
             </activation>
             <modules>
@@ -101,19 +101,30 @@
             </modules>
         </profile>
         <profile>
-            <!-- skip the DEB build by setting -Dno-deb - useful if Debian tools are not available -->
-            <id>deb-module</id>
+            <!-- Include the DEB build by setting -Ddeb -->
+            <id>deb</id>
             <activation>
                 <property>
-                    <name>!no-deb</name>
+                    <name>deb</name>
                 </property>
             </activation>
             <modules>
                 <module>deb-packaging</module>
             </modules>
         </profile>
+        <profile>
+            <!-- Include the Docker build by setting -Ddocker -->
+            <id>docker</id>
+            <activation>
+                <property>
+                    <name>docker</name>
+                </property>
+            </activation>
+            <modules>
+                <module>docker-image</module>
+            </modules>
+        </profile>
     </profiles>
-
 
     <modules>
         <module>downstream-parent</module>
@@ -123,7 +134,6 @@
         <module>vagrant</module>
         <module>archetypes/quickstart</module>
         <module>shared-packaging</module>
-        <module>docker-image</module>
     </modules>
 
     <build>
@@ -135,6 +145,7 @@
                     <excludes combine.children="append">
                         <exclude>scripts/README.md</exclude>
                         <exclude>docker/README.md</exclude>
+                        <exclude>docker-image/README.md</exclude>
                     </excludes>
                 </configuration>
             </plugin>


### PR DESCRIPTION
This disables by default the build of `rpm-packaging`, `deb-package` and `docker-image`. These can be reenabled by doing:
```
mvn clean install -Drpm -Ddeb -Ddocker
```

This is to fix the inconsistency pointed out in this email thread: https://lists.apache.org/thread.html/f296ff5ed96002f165bdef95d0aac083261ff44c78c24c0a804fe4d9@%3Cdev.brooklyn.apache.org%3E

Please note this depends on: https://github.com/apache/brooklyn/pull/30