### PR TITLE
Reuse local maven cache + add PR comment trigger 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,7 +36,7 @@ node(label: 'ubuntu') {
             }
 
             stage('Run tests') {
-                environmentDockerImage.inside('-i --name brooklyn-${DOCKER_TAG} --mount type=bind,source="${HOME}/.m2/settings.xml",target=/var/maven/.m2/settings.xml,readonly -v ${WORKSPACE}:/usr/build -w /usr/build') {
+                environmentDockerImage.inside('-i --name brooklyn-${DOCKER_TAG} -v ${WORKSPACE}/.m2:/var/maven/.m2 --mount type=bind,source="${HOME}/.m2/settings.xml",target=/var/maven/.m2/settings.xml,readonly -v ${WORKSPACE}:/usr/build -w /usr/build') {
                     sh 'mvn clean install -Prpm -Pdeb -Duser.home=/var/maven -Duser.name=jenkins'
                 }
             }
@@ -44,12 +44,10 @@ node(label: 'ubuntu') {
             // Conditional stage to deploy artifacts, when not building a PR
             if (env.CHANGE_ID == null) {
                 stage('Deploy artifacts') {
-                    environmentDockerImage.inside('-i --name brooklyn-${DOCKER_TAG} --mount type=bind,source="${HOME}/.m2/settings.xml",target=/var/maven/.m2/settings.xml,readonly -v ${WORKSPACE}:/usr/build -w /usr/build') {
+                    environmentDockerImage.inside('-i --name brooklyn-${DOCKER_TAG} -v ${WORKSPACE}/.m2:/var/maven/.m2 --mount type=bind,source="${HOME}/.m2/settings.xml",target=/var/maven/.m2/settings.xml,readonly -v ${WORKSPACE}:/usr/build -w /usr/build') {
                         sh 'mvn deploy -Prpm -Pdeb -DskipTests -Duser.home=/var/maven -Duser.name=jenkins'
                     }
                 }
-
-                // TODO: Publish docker image to https://hub.docker.com/r/apache/brooklyn/ ?
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,6 +18,12 @@
  */
 
 node(label: 'ubuntu') {
+    properties([
+        pipelineTriggers([
+            issueCommentTrigger('.*test this please.*')
+        ])
+    ])
+
     catchError {
         def environmentDockerImage
 


### PR DESCRIPTION
This should greatly decrease the build time on Jenkins.

See https://builds.apache.org/job/brooklyn-library/job/master/ and https://builds.apache.org/job/brooklyn-client/job/master/ for the decrease of build time (same changes have been merged over there)