### PR TITLE
BROOKLYN-597 Remove md5/sha1

### DIFF
--- a/release/environment.sh
+++ b/release/environment.sh
@@ -102,10 +102,10 @@ echo >&2 "The continuing version is: ${continue_version}"
 confirm || exit
 
 cat <<EOF
-OLD_MASTER_VERSION=${current_version}
-NEW_MASTER_VERSION=${continue_version}
-VERSION_NAME=${release_version}
-RC_NUMBER=${rc_suffix}
-SUBMODULES="$( perl -n -e 'if ($_ =~ /path += +(.*)$/) { print $1." " }' < .gitmodules )"
-MODULES=". \${SUBMODULES}"
+export OLD_MASTER_VERSION=${current_version}
+export NEW_MASTER_VERSION=${continue_version}
+export VERSION_NAME=${release_version}
+export RC_NUMBER=${rc_suffix}
+export SUBMODULES="$( perl -n -e 'if ($_ =~ /path += +(.*)$/) { print $1." " }' < .gitmodules )"
+export MODULES=". \${SUBMODULES}"
 EOF

--- a/release/make-release-artifacts.sh
+++ b/release/make-release-artifacts.sh
@@ -270,14 +270,12 @@ cp ${src_staging_dir}/brooklyn-dist/deb-packaging/target/apache-brooklyn-${curre
 ###############################################################################
 # Signatures and checksums
 
-# OSX doesn't have sha256sum, even if MacPorts md5sha1sum package is installed.
+# OSX doesn't have sha256sum, even if MacPorts package is installed.
 # Easy to fake it though.
 which sha256sum >/dev/null || alias sha256sum='shasum -a 256' && shopt -s expand_aliases
 
 ( cd ${artifact_dir} &&
     for a in *.tar.gz *.zip *.rpm *.deb; do
-        md5sum -b ${a} > ${a}.md5
-        sha1sum -b ${a} > ${a}.sha1
         sha256sum -b ${a} > ${a}.sha256
         gpg2 --armor --output ${a}.asc --detach-sig ${a}
     done

--- a/release/make-release-artifacts.sh
+++ b/release/make-release-artifacts.sh
@@ -200,9 +200,9 @@ mkdir -p ${bin_staging_dir}
 
 # Perform the build
 if [ -z "${dry_run}" ]; then
-    ( cd ${src_staging_dir} && mvn deploy -Papache-release )
+    ( cd ${src_staging_dir} && mvn deploy -Drpm -Ddeb -Papache-release )
 else
-    ( cd ${src_staging_dir} && mvn install -Papache-release )
+    ( cd ${src_staging_dir} && mvn install -Drpm -Ddeb -Papache-release )
 fi
 
 # Re-pack the archive with the correct names

--- a/release/make-release-artifacts.sh
+++ b/release/make-release-artifacts.sh
@@ -175,9 +175,7 @@ mkdir -p ${src_staging_dir}
 # * sandbox (which hasn't been vetted so thoroughly)
 # * release (where this is running, and people who *have* the release don't need to make it)
 # * jars and friends (these are sometimes included for tests, but those are marked as skippable,
-# * cli/vendor - that's not source controlled and not removed by mvn clean so ignore it in case it's already there
-#     and apache convention does not allow them in source builds; see PR #365
-rsync -rtp --exclude .git\* --exclude brooklyn-docs/ --exclude brooklyn-library/sandbox/ --exclude brooklyn-client/cli/vendor/ --exclude brooklyn-dist/release/ --exclude '**/*.[ejw]ar' . ${staging_dir}/${release_name}-src
+rsync -rtp --exclude .git\* --exclude brooklyn-docs/ --exclude brooklyn-library/sandbox/ --exclude brooklyn-dist/release/ --exclude '**/*.[ejw]ar' . ${staging_dir}/${release_name}-src
 
 rm -rf ${artifact_dir}
 mkdir -p ${artifact_dir}

--- a/release/make-release-artifacts.sh
+++ b/release/make-release-artifacts.sh
@@ -200,9 +200,9 @@ mkdir -p ${bin_staging_dir}
 
 # Perform the build
 if [ -z "${dry_run}" ]; then
-    ( cd ${src_staging_dir} && mvn deploy -Drpm -Ddeb -Papache-release )
+    ( cd ${src_staging_dir} && mvn deploy -Dclient -Drpm -Ddeb -Papache-release )
 else
-    ( cd ${src_staging_dir} && mvn install -Drpm -Ddeb -Papache-release )
+    ( cd ${src_staging_dir} && mvn install -Dclient -Drpm -Ddeb -Papache-release )
 fi
 
 # Re-pack the archive with the correct names

--- a/release/verify_brooklyn_rc.sh
+++ b/release/verify_brooklyn_rc.sh
@@ -25,7 +25,6 @@ if [ "$#" -ne 1 ]; then
 fi
 
 command -v svn >/dev/null 2>&1 || { echo >&2 "[x] svn required but is not installed. Aborting."; exit 1; }
-command -v md5sum >/dev/null 2>&1 || { echo >&2 "[x] md5sum required but is not installed. On macOS install with 'brew install md5sum'. Aborting."; exit 1; }
 command -v shasum >/dev/null 2>&1 || { echo >&2 "[x] shasum required but is not installed. On macOS install with 'brew install shasum'. Aborting."; exit 1; }
 command -v gpg >/dev/null 2>&1 || { echo >&2 "[x] gpg required but is not installed. On macOS install with 'brew install gpg'. Aborting."; exit 1; }
 command -v rpm >/dev/null 2>&1 || { echo >&2 "[x] rpm required but is not installed. On macOS install with 'brew install rpm'. Aborting."; exit 1; }
@@ -80,13 +79,11 @@ echo "= Checking signatures and hashes of artifacts ...                         
 echo "==============================================================================="
 echo
 
-for ARTIFACT in $(find * -type f ! \( -name '*.asc' -o -name '*.md5' -o -name '*.sha1' -o -name '*.sha256' \) ); do
-  md5sum -c ${ARTIFACT}.md5 && \
-  shasum -a1 -c ${ARTIFACT}.sha1 && \
+find * -type f ! \( -name '*.asc' -o -name '*.sha256' \) -print | while read -r ARTIFACT ; do
   shasum -a256 -c ${ARTIFACT}.sha256 && \
   gpg --verify ${ARTIFACT}.asc ${ARTIFACT} && \
-  echo "[✓] Signatures verified for $ARTIFACT" \
-    || { echo "[x] Invalid signature for $ARTIFACT. Aborting."; exit 1; }
+  echo "[✓] Signatures verified for ${ARTIFACT}" \
+    || { echo "[x] Invalid signature for ${ARTIFACT}. Aborting."; exit 1; }
 done
 
 echo
@@ -96,7 +93,7 @@ echo "==========================================================================
 echo
 
 GA_RELEASE=${RELEASE%%-rc?}
-for ARCHIVE in $(ls *.{tar.gz,zip,rpm}); do
+find * -type f \( -name '*.tar.gz' -or -name '*.zip' -or -name '*.rpm' \) -print | while read -r ARCHIVE ; do
   REL_ARCHIVE=${ARCHIVE/-rc?}
   case $ARCHIVE in
     *.tar.gz)


### PR DESCRIPTION
Remove MD5 and SHA-1 for [BROOKLYN-597](https://issues.apache.org/jira/projects/BROOKLYN/issues/BROOKLYN-597)

Merge after https://github.com/apache/brooklyn-ui/pull/160

Also simplifies the artifact signing, just hashing the artifacts and signing only the SHA256SUMS file.

Details per JIRA:


Per the recently updated Apache Release Distribution Policy, https://www.apache.org/dev/release-distribution, we should remove the generation and checking of MD5 and SHA-1 checksums from brooklyn-dist/release before we do another release, presumably 1.0.

The relevant wording is 

For every artifact distributed to the public through Apache channels, the PMC

MUST supply a valid OpenPGP-compatible ASCII-armored detached signature file
MUST supply at least one checksum file
SHOULD supply a SHA-256 and/or SHA-512 checksum file
SHOULD NOT supply a MD5 or SHA-1 checksum file (because these are deprecated)
For new releases, PMCs MUST supply SHA-256 and/or SHA-512; and SHOULD NOT supply MD5 or SHA-1. Existing releases do not need to be changed.