### PR TITLE
fix javaasist collision

### DIFF
--- a/karaf/apache-brooklyn/pom.xml
+++ b/karaf/apache-brooklyn/pom.xml
@@ -63,6 +63,12 @@
       <version>${project.version}</version>
       <type>xml</type>
       <classifier>features</classifier>
+      <exclusions>
+        <exclusion>
+          <groupId>org.javassist</groupId>
+          <artifactId>javassist</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Brookyn build is failing when you try to package as RMP: https://ci-builds.apache.org/job/Brooklyn/job/brooklyn/job/master/5/console

The error is
```
Failed while enforcing releasability the error(s) are [
Dependency convergence error for org.javassist:javassist:3.24.0-GA paths to dependency are:
+-org.apache.brooklyn:rpm-packaging:1.1.0-SNAPSHOT
  +-org.apache.brooklyn:apache-brooklyn:1.1.0-SNAPSHOT
    +-org.apache.karaf.features:enterprise:4.2.8
      +-org.hibernate:hibernate-osgi:5.4.8.Final
        +-org.hibernate:hibernate-core:5.4.8.Final
          +-org.javassist:javassist:3.24.0-GA
and
+-org.apache.brooklyn:rpm-packaging:1.1.0-SNAPSHOT
  +-org.apache.brooklyn:apache-brooklyn:1.1.0-SNAPSHOT
    +-org.apache.brooklyn:brooklyn-features:1.1.0-SNAPSHOT
      +-org.apache.brooklyn:brooklyn-rest-resources:1.1.0-SNAPSHOT
        +-org.reflections:reflections:0.9.10
          +-org.javassist:javassist:3.19.0-GA
```
