### PR TITLE
Bumping dependencies

### DIFF
--- a/karaf/features/src/main/feature/feature.xml
+++ b/karaf/features/src/main/feature/feature.xml
@@ -53,6 +53,9 @@
     </feature>
 
     <feature name="brooklyn-startup-features" version="${project.version}" description="Bundles to add to startup.properties">
+        <!--        <bundle dependency="true">mvn:org.apache.servicemix.specs.activation-api-1.1</bundle>-->
+<!--        <bundle dependency="true">mvn:org.apache.servicemix.specs.activation-api-1.1/2.9.0</bundle>-->
+        <bundle dependency='true'>wrap:mvn:javax.activation/activation/1.1</bundle>
         <!-- Register javax.mail along with pax-logging-service so it doesn't get refreshed later -->
         <bundle>mvn:javax.mail/mail/${javax.mail.version}</bundle>
     </feature>

--- a/karaf/features/src/main/feature/feature.xml
+++ b/karaf/features/src/main/feature/feature.xml
@@ -54,10 +54,10 @@
 
     <feature name="brooklyn-startup-features" version="${project.version}" description="Bundles to add to startup.properties">
         <!--        <bundle dependency="true">mvn:org.apache.servicemix.specs.activation-api-1.1</bundle>-->
-<!--        <bundle dependency="true">mvn:org.apache.servicemix.specs.activation-api-1.1/2.9.0</bundle>-->
-        <bundle dependency='true'>wrap:mvn:javax.activation/activation/1.1</bundle>
+        <!--        <bundle dependency="true">mvn:org.apache.servicemix.specs.activation-api-1.1/2.9.0</bundle>-->
+        <bundle dependency="true">mvn:com.sun.activation/jakarta.activation/${jakarta.activation.version>}</bundle>
         <!-- Register javax.mail along with pax-logging-service so it doesn't get refreshed later -->
-        <bundle>mvn:javax.mail/mail/${javax.mail.version}</bundle>
+        <bundle dependency="true">mvn:javax.mail/mail/${javax.mail.version}</bundle>
     </feature>
 
     <feature name="brooklyn-guava-optional-deps" version="${project.version}" description="Guava dependencies to avoid refreshing the bundle">

--- a/karaf/itest/pom.xml
+++ b/karaf/itest/pom.xml
@@ -111,7 +111,7 @@
 
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>org.osgi.core</artifactId>
+            <artifactId>osgi.core</artifactId>
             <version>${org.osgi.core.version}</version>
             <scope>provided</scope>
         </dependency>

--- a/karaf/pom.xml
+++ b/karaf/pom.xml
@@ -45,7 +45,7 @@
         <pax.exam.version>4.13.1</pax.exam.version>
         <pax.url.version>2.5.2</pax.url.version>
 
-        <ops4j.base.version>1.5.0</ops4j.base.version>
+        <ops4j.base.version>1.5.1</ops4j.base.version>
         <tinybundles.version>1.0.0</tinybundles.version>
 
         <!-- feature repositories -->


### PR DESCRIPTION
Several dependency versions updated to fix known vulnerabilities.
See https://github.com/apache/brooklyn-server/pull/1140