### PR TITLE
Mvn 3.8.1 will refuse to use http repos

### DIFF
--- a/archetypes/quickstart/pom.xml
+++ b/archetypes/quickstart/pom.xml
@@ -45,7 +45,7 @@
     <repository>
       <id>apache.snapshots</id>
       <name>Apache Snapshot Repository</name>
-      <url>http://repository.apache.org/snapshots</url>
+      <url>https://repository.apache.org/snapshots</url>
       <releases>
         <enabled>false</enabled>
       </releases>

--- a/archetypes/quickstart/src/brooklyn-sample/pom.xml
+++ b/archetypes/quickstart/src/brooklyn-sample/pom.xml
@@ -54,7 +54,7 @@
     <repository>
       <id>apache.snapshots</id>
       <name>Apache Snapshot Repository</name>
-      <url>http://repository.apache.org/snapshots</url>
+      <url>https://repository.apache.org/snapshots</url>
       <releases>
         <enabled>false</enabled>
       </releases>

--- a/downstream-parent/pom.xml
+++ b/downstream-parent/pom.xml
@@ -50,7 +50,7 @@
     <repository>
       <id>apache.snapshots</id>
       <name>Apache Snapshot Repository</name>
-      <url>http://repository.apache.org/snapshots</url>
+      <url>https://repository.apache.org/snapshots</url>
       <releases>
         <enabled>false</enabled>
       </releases>

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
         <repository>
             <id>apache.snapshots</id>
             <name>Apache Snapshot Repository</name>
-            <url>http://repository.apache.org/snapshots</url>
+            <url>https://repository.apache.org/snapshots</url>
             <releases>
                 <enabled>false</enabled>
             </releases>


### PR DESCRIPTION
What's especially annoying is it does this pretty quietly so as long as there is something in the m2 cache it'll build ok

I've updated to  https which works even though repository.apache returns
a 302 to the http endpoint apparently that's ok