### PR TITLE
Add support setup default initializers for all deployment

### DIFF
--- a/karaf/features/src/main/resources/resources/etc/brooklyn.cfg
+++ b/karaf/features/src/main/resources/resources/etc/brooklyn.cfg
@@ -30,3 +30,7 @@ brooklyn.webconsole.security.provider = org.apache.brooklyn.rest.security.provid
 
 # Refer to the documentation for other auth settings, including LDAP, and other settings
 
+# Default initializers to automatically add to any application deployed with Brooklyn
+# This expect a comma separated list of initializer class names
+#brooklyn.deployment.initializers=
+

--- a/karaf/features/src/main/resources/resources/etc/brooklyn.cfg
+++ b/karaf/features/src/main/resources/resources/etc/brooklyn.cfg
@@ -32,5 +32,5 @@ brooklyn.webconsole.security.provider = org.apache.brooklyn.rest.security.provid
 
 # Default initializers to automatically add to any application deployed with Brooklyn
 # This expect a comma separated list of initializer class names
-#brooklyn.deployment.initializers=
+brooklyn.deployment.initializers=org.apache.brooklyn.core.effector.AddDeploySensorsInitializer
 


### PR DESCRIPTION
This looks up a new configuration options called `brooklyn.deployment.initializers` (comma separated list). If specified on a Brooklyn instance, all deployments will load and execute these initializers. Theses classes are expected to be `EntityInitializer`, if an error occur (either cast or anything else) then the deployment will fail.

The code will try to:
1. load the class from the default class loader.
2. if (1) fails, it will try to load the class from the `TypeRegistry`. This is to allow execution of custom initializers that might be installed in the catalog later on.
3. if (1) and (2) fails, then the deployment is aborted.

This PR adds the configuration to allow the above, which is done by https://github.com/apache/brooklyn-server/pull/1200