### PR TITLE
Config logs for using UTC time by default instead of local time

### DIFF
--- a/karaf/features/src/main/resources/resources/etc/org.ops4j.pax.logging.cfg
+++ b/karaf/features/src/main/resources/resources/etc/org.ops4j.pax.logging.cfg
@@ -18,7 +18,7 @@
 ################################################################################
 
 # Common pattern layout for appenders
-log4j2.pattern = %d{ISO8601} %X{task.id}-%X{entity.ids} %-5.5p %3X{bundle.id} %c{1.} [%.16t] %m%n
+log4j2.pattern = %d{ISO8601}{UTC}Z %X{task.id}-%X{entity.ids} %-5.5p %3X{bundle.id} %c{1.} [%.16t] %m%n
 
 ###############
 # Root logger #


### PR DESCRIPTION
See difference
```
2021-08-21T16:10:42,525 - INFO   49 o.a.a.b.c.BlueprintContainerImpl [FelixStartLevel] Blueprint bundle org.apache.aries.blueprint.core/1.10.2 has been started
```

```
2021-08-21T15:10:42,703Z - INFO    6 o.o.p.l.s.s.EventAdminConfigurationNotifier [s4j.pax.logging)] Sending Event Admin notification (configuration successful) to org/ops4j/pax/logging/Configuration
```

